### PR TITLE
Update to v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,12 +257,12 @@ function flameGraph (opts) {
         data
           .sort(doSort)
           .sum(function (d) {
-            return d ? (d.v || d.value) : 0 
+            return d ? (d.v || d.value) : 0
           })
-        
+
         var nodes = partition(data)
 
-        var kx = data.x1 / w
+        var kx = w
         var svg = d3.select(this).select('svg')
         var g = svg.selectAll('g').data(data.descendants())
 

--- a/index.js
+++ b/index.js
@@ -181,9 +181,9 @@ function flameGraph (opts) {
     }
   }
 
-  function augment (data) {
+  function categorizeTree (data) {
     if (data.children && (data.children.length > 0)) {
-      data.children.forEach(augment)
+      data.children.forEach(categorizeTree)
       data.children.forEach(function (child, ix, children) {
         var lt = categorizer(child.data, ix, children)
         child.data.type = lt.type
@@ -453,7 +453,7 @@ function flameGraph (opts) {
         .append('style')
           .text(css)
 
-      augment(data)
+      categorizeTree(data)
       filter(data)
 
       // first draw
@@ -552,10 +552,8 @@ function flameGraph (opts) {
         selection.each(function (data) {
         allSamples = data.value
 
-        augment(data)
+        categorizeTree(data)
         filter(data)
-        // "creative" fix for node ordering when partition is called for the first time
-        // partition(data)
 
         // first draw
         update()

--- a/index.js
+++ b/index.js
@@ -239,17 +239,24 @@ function flameGraph (opts) {
           var dx = d.x1 - d.x0
           return dx * w / rootDx
         }
+        function sumChildValues (a, b) {
+          return a + (b.hide ? 0 : b.value)
+        }
 
         filter(data)
 
         data
           .sum(function (d) {
+            if (d.hide) return 0
             const childValues = d.children
-              ? d.children.reduce((a, b) => a + b.value, 0)
+              ? d.children.reduce(sumChildValues, 0)
               : 0
             return d.value - childValues
           })
           .sort(doSort)
+
+        // Make "all stacks" as wide as every visible stack.
+        data.value = data.children.reduce(sumChildValues, 0)
 
         var nodes = partition(data)
 

--- a/index.js
+++ b/index.js
@@ -45,31 +45,31 @@ function flameGraph (opts) {
 
   function label (d) {
     if (d.dummy) return ''
-    if (!d.parent) return d.name
+    if (!d.parent) return d.data.name
 
-    var onStack = d.name ? Math.round(100 * (d.value / allSamples), 1) + '% on stack' : ''
+    var onStack = d.data.name ? Math.round(100 * (d.data.value / allSamples), 1) + '% on stack' : ''
     var top = stackTop(d)
-    var topOfStack = d.name ? (top
+    var topOfStack = d.data.name ? (top
       ? Math.round(100 * (top / allSamples), 2) + '% stack top'
       : '') : ''
 
     if (onStack && topOfStack) { onStack += ', ' }
 
-    return d.name + ' <small>' + onStack + ' ' + topOfStack + '</small>'
+    return d.data.name + ' <small>' + onStack + ' ' + topOfStack + '</small>'
   }
 
   function titleLabel (d) {
     if (!d.parent) return ''
     var top = stackTop(d)
-    return d.name + '\n' + (top
+    return d.data.name + '\n' + (top
       ? 'Top of Stack:' + Math.round(100 * (top / allSamples), 1) + '% ' +
       '(' + top + ' of ' + allSamples + ' samples)\n'
-      : '') + 'On Stack:' + Math.round(100 * (d.value / allSamples), 1) + '% ' +
-     '(' + d.value + ' of ' + allSamples + ' samples)'
+      : '') + 'On Stack:' + Math.round(100 * (d.data.value / allSamples), 1) + '% ' +
+     '(' + d.data.value + ' of ' + allSamples + ' samples)'
   }
 
   function categorize (child) {
-    var name = child.name
+    var name = child.data.name
 
     // todo: C deps
     if (!/.js/.test(name)) {
@@ -138,9 +138,9 @@ function flameGraph (opts) {
 
   function hide (d) {
     if (!d.original) {
-      d.original = d.value
+      d.original = d.data.value
     }
-    d.value = 0
+    d.data.value = 0
     if (d.children) {
       d.children.forEach(hide)
     }
@@ -149,7 +149,7 @@ function flameGraph (opts) {
   function show (d) {
     d.fade = false
     if (d.original) {
-      d.value = d.original
+      d.data.value = d.original
     }
     if (d.children) {
       d.children.forEach(show)
@@ -192,7 +192,7 @@ function flameGraph (opts) {
 
   function searchTree (d, term, color) {
     var re = term instanceof RegExp ? term : new RegExp(rxEsc(term), 'i') 
-    var label = d.name
+    var label = d.data.name
 
     if (d.children) {
       d.children.forEach(function (child) {
@@ -300,7 +300,7 @@ function flameGraph (opts) {
 
         node.attr('width', function (d) { return (d.x1 - d.x0) * kx })
           .attr('height', function (d) { return c })
-          .attr('name', function (d) { return d.name })
+          .attr('name', function (d) { return d.data.name })
           .attr('class', function (d) { return d.fade ? 'frame fade' : 'frame' })
 
         g.select('rect')
@@ -308,7 +308,7 @@ function flameGraph (opts) {
           .style('cursor', 'pointer')
           .style('stroke', function (d) {
             if (!d.parent) return 'rgba(0,0,0,0.7)'
-            return colorHash(d, 1.1, allSamples, tiers)
+            return colorHash(d.data, 1.1, allSamples, tiers)
           })
           .attr('fill', function (d) {
             if (!d.parent) return '#FFF'
@@ -317,7 +317,7 @@ function flameGraph (opts) {
             if (typeof d.highlight === 'string') {
               highlightColor = d.highlight
             }
-            return d.highlight ? highlightColor : colorHash(d, undefined, allSamples, tiers)
+            return d.highlight ? highlightColor : colorHash(d.data, undefined, allSamples, tiers)
           })
           .style('visibility', function (d) { return d.dummy ? 'hidden' : 'visible' })
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ function eventPath (event) {
 
 function flameGraph (opts) {
   var tree = opts.tree
-  window.tree = tree
   var timing = opts.timing || false
   var element = opts.element
   var c = 18 // cell height

--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ function flameGraph (opts) {
     if (typeof sort === 'function') {
       return sort(a, b)
     } else if (sort) {
-      return d3.ascending(a.name, b.name)
+      return d3.ascending(a.value.name, b.value.name)
     } else {
       return 0
     }

--- a/index.js
+++ b/index.js
@@ -337,6 +337,11 @@ function flameGraph (opts) {
           .attr('width', frameWidth)
         console.timeEnd('transition')
 
+        console.time('exit')
+        var exit = g.exit()
+        exit.remove()
+        console.timeEnd('exit')
+
         console.time('enter')
         var node = g.enter()
           .append('svg:g')
@@ -353,6 +358,7 @@ function flameGraph (opts) {
         node.append('foreignObject')
           .style('overflow', 'hidden')
           .style('pointer-events', 'none')
+          .attr('width', frameWidth)
           .append('xhtml:div')
             .style('white-space', 'nowrap')
             .style('text-overflow', 'ellipsis')
@@ -373,13 +379,15 @@ function flameGraph (opts) {
           .classed('frame', true)
         console.timeEnd('enter')
 
+        var all = g.merge(node)
+
         console.time('g:fade')
-        g.select('g')
+        all.select('g')
           .classed('fade', function (d) { return d.data.fade })
         console.timeEnd('g:fade')
 
         console.time('rect')
-        g.select('rect')
+        all.select('rect')
           .attr('height', function (d) { return d.data.hide ? 0 : c })
           .style('stroke', function (d) {
             if (!d.parent) return 'rgba(0,0,0,0.7)'
@@ -397,20 +405,19 @@ function flameGraph (opts) {
         console.timeEnd('rect')
 
         console.time('text')
-        g.select('foreignObject')
+        all.select('foreignObject')
           .attr('height', function (d) { return d.data.hide ? 0 : c })
           .select('div')
-          .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })
-          .style('text-align', function (d) {
-            return d.parent ? 'left' : 'center'
-          })
+            .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })
+            .style('text-align', function (d) {
+              return d.parent ? 'left' : 'center'
+            })
         console.timeEnd('text')
 
-        g.on('click', zoom)
+        all.on('click', zoom)
 
-        var hidden = g.filter(function (d) { return d.hide })
+        var hidden = all.filter(function (d) { return d.hide })
         hidden.each(hide)
-        g.exit().remove()
       })
     console.groupEnd('update')
   }
@@ -432,11 +439,6 @@ function flameGraph (opts) {
       filter(data)
 
       // first draw
-      // goto-bus-stop: Doing this twice because lots of the reactive functions in
-      // update() are not called the first time? No clue why that happens but calling
-      // this twice works… Without this the <foreignObject> elements are empty etc and
-      // none of the frames are visible.
-      update()
       update()
     })
   }

--- a/index.js
+++ b/index.js
@@ -82,17 +82,19 @@ function flameGraph (opts) {
     return onStack + topOfStack
   }
   function label (d) {
-    var name = document.createTextNode(labelName(d))
+    var name = labelName(d)
     var stack = labelStack(d)
+    // creating raw DOM here saves the browser a bunch of time parsing
+    // thousands of tiny html snippets
     if (stack) {
       var frag = document.createDocumentFragment()
       var small = document.createElement('small')
       small.appendChild(document.createTextNode(stack))
-      frag.appendChild(name)
+      frag.appendChild(document.createTextNode(name + ' '))
       frag.appendChild(small)
       return frag
     }
-    return name
+    return document.createTextNode(name)
   }
 
   function titleLabel (d) {

--- a/index.js
+++ b/index.js
@@ -239,6 +239,7 @@ function flameGraph (opts) {
           return dx * w
         }
         function sumChildValues (a, b) {
+          // If a child is hidden or is an ancestor of the focused frame, don't count it
           return a + (b.hide || b.fade ? 0 : b.value)
         }
 
@@ -246,7 +247,12 @@ function flameGraph (opts) {
 
         data
           .sum(function (d) {
+            // If this is the ancestor of a focused frame, use the same value (width) as the focused frame.
             if (d.fade) return d.children.reduce(sumChildValues, 0)
+
+            // d3 sums value + all child values to get the value for a node,
+            // we can set `value = specifiedValue - all child values` to counteract that.
+            // the `.value`s in our data already include the sum of all child values.
             const childValues = d.children
               ? d.children.reduce(sumChildValues, 0)
               : 0
@@ -370,10 +376,10 @@ function flameGraph (opts) {
       filter(data)
 
       // first draw
-      // goto-bus-stop: Doing this twice because the `label()` function is not
-      // called the first time? No clue why that happens but calling this twice works…
-      // Without this the <foreignObject> elements are empty etc and none of the
-      // frames are visible.
+      // goto-bus-stop: Doing this twice because lots of the reactive functions in
+      // update() are not called the first time? No clue why that happens but calling
+      // this twice works… Without this the <foreignObject> elements are empty etc and
+      // none of the frames are visible.
       update()
       update()
     })

--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ function flameGraph (opts) {
         }
         function sumChildValues (a, b) {
           // If a child is hidden or is (an ancestor of) the focused frame, don't count it
-          return a + (b.hide || b.fade || b === focused ? 0 : b.value)
+          return a + (b.fade || b === focused ? 0 : b.value)
         }
 
         time('filter', function () {
@@ -325,7 +325,7 @@ function flameGraph (opts) {
 
         var svg = d3.select(this).select('svg')
         var g = svg.selectAll('g').data(
-          data.descendants().filter(function (d) { return !d.data.hide })
+          data.descendants()
         )
 
         svg.on('click', function (d) {
@@ -432,9 +432,6 @@ function flameGraph (opts) {
         })
 
         all.on('click', zoom)
-
-        var hidden = all.filter(function (d) { return d.hide })
-        hidden.each(hide)
       })
     if (timing) console.groupEnd('update')
   }

--- a/index.js
+++ b/index.js
@@ -231,6 +231,10 @@ function flameGraph (opts) {
     return 'translate(' + x(d.x0) + ',' + (h - (depth * c) - c) + ')'
   }
 
+  function frameWidth (d) {
+    return (d.x1 - d.x0) * w
+  }
+
   function update () {
     selection
       .each(function (data) {
@@ -244,7 +248,6 @@ function flameGraph (opts) {
 
         var nodes = partition(data)
 
-        var kx = w
         var svg = d3.select(this).select('svg')
         var g = svg.selectAll('g').data(data.descendants())
 
@@ -262,9 +265,7 @@ function flameGraph (opts) {
         g.select('rect').transition()
           .duration(transitionDuration)
           .ease(transitionEase)
-          .attr('width', function (d) {
-            return (d.x1 - d.x0) * kx
-          })
+          .attr('width', frameWidth)
 
         var node = g.enter()
           .append('svg:g')
@@ -273,14 +274,14 @@ function flameGraph (opts) {
 
         node
           .append('svg:rect')
-          .attr('width', function (d) { return (d.x1 - d.x0) * kx })
+          .attr('width', frameWidth)
 
         node.append('svg:title')
 
         node.append('foreignObject')
           .append('xhtml:div')
 
-        node.attr('width', function (d) { return (d.x1 - d.x0) * kx })
+        node.attr('width', frameWidth)
           .attr('height', function (d) { return c })
           .attr('name', function (d) { return d.data.name })
           .attr('class', function (d) { return d.data.fade ? 'frame fade' : 'frame' })
@@ -309,13 +310,13 @@ function flameGraph (opts) {
           .transition()
           .duration(transitionDuration)
           .ease(transitionEase)
-          .attr('width', function (d) { return (d.x1 - d.x0) * kx })
+          .attr('width', frameWidth)
 
         g.select('foreignObject')
           .style('overflow', 'hidden')
           .attr('height', function (d) { return d.data.hide ? 0 : c })
           .select('div')
-          .style('display', function (d) { return ((d.x1 - d.x0) * kx < 35) ? 'none' : 'block' })
+          .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })
           .style('pointer-events', 'none')
           .style('white-space', 'nowrap')
           .style('text-overflow', 'ellipsis')
@@ -345,7 +346,7 @@ function flameGraph (opts) {
     selection = d3.select(element)
 
     selection.each(function (data) {
-      allSamples = data.value
+      allSamples = data.data.value
 
       if (!firstRender) d3.select(this)
         .append('svg:svg')

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ function flameGraph (opts) {
   var minHeight = opts.minHeight || 950
   h = h < minHeight ? minHeight : h
   var w = opts.width || document.body.clientWidth * 0.89 // graph width
+  var scaleWidth = d3.scaleLinear().range([0, w])
   var selection = null // selection
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -297,14 +298,13 @@ function flameGraph (opts) {
   var partition = d3.partition()
 
   function translate (d) {
-    var x = d3.scaleLinear().range([0, w])
     var parent = d.parent
     var depthOffset = parent && parent.data.hide ? 1 : 0
     while (parent && (parent = parent.parent)) {
       if (parent.data.hide) depthOffset += 1
     }
     var depth = d.depth - depthOffset
-    return 'translate(' + x(d.x0) + ',' + (h - (depth * c) - c) + ')'
+    return 'translate(' + scaleWidth(d.x0) + ',' + (h - (depth * c) - c) + ')'
   }
 
   function update () {
@@ -410,8 +410,7 @@ function flameGraph (opts) {
         var all = g.merge(node)
 
         time('g:fade', function () {
-          all.select('g')
-            .classed('fade', function (d) { return d.data.fade })
+          all.classed('fade', function (d) { return d.data.fade })
         })
 
         time('rect', function () {
@@ -479,6 +478,7 @@ function flameGraph (opts) {
   chart.width = function (_) {
     if (!arguments.length) { return w }
     w = _
+    scaleWidth = d3.scaleLinear().range([0, w])
     return chart
   }
 

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ function flameGraph (opts) {
   }
 
   function searchTree (d, term, color) {
-    var re = term instanceof RegExp ? term : new RegExp(rxEsc(term), 'i') 
+    var re = term instanceof RegExp ? term : new RegExp(rxEsc(term), 'i')
     var label = d.data.name
 
     if (d.children) {
@@ -437,7 +437,9 @@ function flameGraph (opts) {
   }
 
   chart.setGraphZoom = function (n) {
-    svg.style.transform = 'scale(' + n + ')'
+    d3.select(element)
+      .select('svg')
+      .style('transform', 'scale(' + n + ')')
   }
 
   chart.renderTree = function (data) {

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
 var css = `
-  .d3-flame-graph rect.frame {
+  .d3-flame-graph .frame rect {
     cursor: pointer;
   }
 

--- a/index.js
+++ b/index.js
@@ -43,9 +43,11 @@ function flameGraph (opts) {
   var categorizer = opts.categorizer || categorize
   var exclude = opts.exclude || []
 
-  function label (d) {
-    if (!d.parent) return d.data.name
-
+  function labelName (d) {
+    return d.data.name
+  }
+  function labelStack (d) {
+    if (!d.parent) return null
     var onStack = d.data.name ? Math.round(100 * (d.data.value / allSamples), 1) + '% on stack' : ''
     var top = stackTop(d)
     var topOfStack = d.data.name ? (top
@@ -54,7 +56,20 @@ function flameGraph (opts) {
 
     if (onStack && topOfStack) { onStack += ', ' }
 
-    return d.data.name + ' <small>' + onStack + ' ' + topOfStack + '</small>'
+    return onStack + topOfStack
+  }
+  function label (d) {
+    var name = document.createTextNode(labelName(d))
+    var stack = labelStack(d)
+    if (stack) {
+      var frag = document.createDocumentFragment()
+      var small = document.createElement('small')
+      small.appendChild(document.createTextNode(stack))
+      frag.appendChild(name)
+      frag.appendChild(small)
+      return frag
+    }
+    return name
   }
 
   function titleLabel (d) {
@@ -288,7 +303,6 @@ function flameGraph (opts) {
           .append('svg:g')
           .attr('transform', translate)
 
-
         node
           .append('svg:rect')
           .attr('width', frameWidth)
@@ -297,6 +311,7 @@ function flameGraph (opts) {
 
         node.append('foreignObject')
           .append('xhtml:div')
+            .append(label)
 
         node.attr('width', frameWidth)
           .attr('height', function (d) { return c })
@@ -349,7 +364,6 @@ function flameGraph (opts) {
           .style('text-align', function (d) {
             return d.parent ? 'left' : 'center'
           })
-          .html(label)
 
         g.on('click', zoom)
 

--- a/index.js
+++ b/index.js
@@ -235,9 +235,8 @@ function flameGraph (opts) {
     selection
       .each(function (data) {
         function frameWidth (d) {
-          var rootDx = data.x1 - data.x0
           var dx = d.x1 - d.x0
-          return dx * w / rootDx
+          return dx * w
         }
         function sumChildValues (a, b) {
           return a + (b.hide || b.fade ? 0 : b.value)

--- a/index.js
+++ b/index.js
@@ -18,6 +18,31 @@ colors.def = {h: 10, s: 66, l: 80}
 colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
+var css = `
+  .d3-flame-graph rect.frame {
+    cursor: pointer;
+  }
+
+  .d3-flame-graph .frame foreignObject {
+    overflow: hidden;
+    pointer-events: none;
+  }
+
+  .d3-flame-graph .frame div {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    font-size: 12px;
+    font-family: Verdana;
+    margin-left: 4px;
+    margin-right: 4px;
+    line-height: 1.5;
+    padding: 0;
+    font-weight: 400;
+    color: #000;
+  }
+`
+
 function eventPath (event) {
   if (event.path) return event.path
   if (event.composedPath) return event.composedPath()
@@ -364,28 +389,14 @@ function flameGraph (opts) {
 
           node
             .append('svg:rect')
-            .style('cursor', 'pointer')
             .attr('width', frameWidth)
 
           node.append('svg:title')
             .text(titleLabel)
 
           node.append('foreignObject')
-            .style('overflow', 'hidden')
-            .style('pointer-events', 'none')
             .attr('width', frameWidth)
             .append('xhtml:div')
-              .style('white-space', 'nowrap')
-              .style('text-overflow', 'ellipsis')
-              .style('overflow', 'hidden')
-              .style('font-size', '12px')
-              .style('font-family', 'Verdana')
-              .style('margin-left', '4px')
-              .style('margin-right', '4px')
-              .style('line-height', '1.5')
-              .style('padding', '0')
-              .style('font-weight', '400')
-              .style('color', '#000')
               .append(label)
 
           node.attr('width', frameWidth)
@@ -448,6 +459,8 @@ function flameGraph (opts) {
         .attr('height', h)
         .attr('class', 'partition d3-flame-graph')
         .attr('transition', 'transform 200ms ease-in-out')
+        .append('style')
+          .text(css)
 
       augment(data)
       filter(data)

--- a/index.js
+++ b/index.js
@@ -311,7 +311,7 @@ function flameGraph (opts) {
         console.timeEnd('partition')
 
         var svg = d3.select(this).select('svg')
-        var g = svg.selectAll('g').data(data.descendants())
+        var g = svg.selectAll('g').data(data.descendants().filter(function (d) { return !d.data.hide }))
 
         svg.on('click', function (d) {
           if (eventPath(d3.event)[0] === this) {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function flameGraph (opts) {
   var filterNeeded = true
   var filterTypes = []
   var allSamples
+  var focused = null
 
   function time (name, fn) {
     if (timing) {
@@ -205,6 +206,7 @@ function flameGraph (opts) {
 
   function zoom (d) {
     time('zoom', function () {
+      focused = d.data
       time('hideSiblings', function () {
         hideSiblings(d)
       })
@@ -287,8 +289,8 @@ function flameGraph (opts) {
           return dx * w
         }
         function sumChildValues (a, b) {
-          // If a child is hidden or is an ancestor of the focused frame, don't count it
-          return a + (b.hide || b.fade ? 0 : b.value)
+          // If a child is hidden or is (an ancestor of) the focused frame, don't count it
+          return a + (b.hide || b.fade || b === focused ? 0 : b.value)
         }
 
         time('filter', function () {

--- a/index.js
+++ b/index.js
@@ -320,7 +320,9 @@ function flameGraph (opts) {
         })
 
         var svg = d3.select(this).select('svg')
-        var g = svg.selectAll('g').data(data.descendants().filter(function (d) { return !d.data.hide }))
+        var g = svg.selectAll('g').data(
+          data.descendants().filter(function (d) { return !d.data.hide })
+        )
 
         svg.on('click', function (d) {
           if (eventPath(d3.event)[0] === this) {

--- a/index.js
+++ b/index.js
@@ -19,19 +19,13 @@ colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
 var css = `
-  .d3-flame-graph .frame {
-    transition: transform 500ms ease-in-out;
-  }
-
   .d3-flame-graph .frame rect {
     cursor: pointer;
-    transition: width 500ms ease-in-out;
   }
 
   .d3-flame-graph .frame foreignObject {
     overflow: hidden;
     pointer-events: none;
-    transition: width 500ms ease-in-out;
   }
 
   .d3-flame-graph .frame div {
@@ -365,6 +359,24 @@ function flameGraph (opts) {
           }
         })
 
+        time('transition', function () {
+          g.transition()
+            .duration(transitionDuration)
+            .ease(transitionEase)
+            .attr('transform', translate)
+
+          g.select('rect').transition()
+            .duration(transitionDuration)
+            .ease(transitionEase)
+            .attr('width', frameWidth)
+
+          g.select('foreignObject')
+            .transition()
+            .duration(transitionDuration)
+            .ease(transitionEase)
+            .attr('width', frameWidth)
+        })
+
         time('exit', function () {
           var exit = g.exit()
           exit.remove()
@@ -398,14 +410,11 @@ function flameGraph (opts) {
         var all = g.merge(node)
 
         time('g:fade', function () {
-          all
-            .classed('fade', function (d) { return d.data.fade })
-            .attr('transform', translate)
+          all.classed('fade', function (d) { return d.data.fade })
         })
 
         time('rect', function () {
           all.select('rect')
-            .attr('width', frameWidth)
             .attr('height', function (d) { return d.data.hide ? 0 : c })
             .style('stroke', function (d) {
               if (!d.parent) return 'rgba(0,0,0,0.7)'
@@ -424,7 +433,6 @@ function flameGraph (opts) {
 
         time('text', function () {
           all.select('foreignObject')
-            .attr('width', frameWidth)
             .attr('height', function (d) { return d.data.hide ? 0 : c })
             .select('div')
               .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })

--- a/index.js
+++ b/index.js
@@ -241,10 +241,13 @@ function flameGraph (opts) {
         filter(data)
 
         data
-          .sort(doSort)
           .sum(function (d) {
-            return d ? (d.v || d.value) : 0
+            const childValues = d.children
+              ? d.children.reduce((a, b) => a + b.value, 0)
+              : 0
+            return d.value - childValues
           })
+          .sort(doSort)
 
         var nodes = partition(data)
 

--- a/index.js
+++ b/index.js
@@ -19,13 +19,19 @@ colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
 var css = `
+  .d3-flame-graph .frame {
+    transition: transform 500ms ease-in-out;
+  }
+
   .d3-flame-graph .frame rect {
     cursor: pointer;
+    transition: width 500ms ease-in-out;
   }
 
   .d3-flame-graph .frame foreignObject {
     overflow: hidden;
     pointer-events: none;
+    transition: width 500ms ease-in-out;
   }
 
   .d3-flame-graph .frame div {
@@ -359,24 +365,6 @@ function flameGraph (opts) {
           }
         })
 
-        time('transition', function () {
-          g.transition()
-            .duration(transitionDuration)
-            .ease(transitionEase)
-            .attr('transform', translate)
-
-          g.select('rect').transition()
-            .duration(transitionDuration)
-            .ease(transitionEase)
-            .attr('width', frameWidth)
-
-          g.select('foreignObject')
-            .transition()
-            .duration(transitionDuration)
-            .ease(transitionEase)
-            .attr('width', frameWidth)
-        })
-
         time('exit', function () {
           var exit = g.exit()
           exit.remove()
@@ -410,11 +398,14 @@ function flameGraph (opts) {
         var all = g.merge(node)
 
         time('g:fade', function () {
-          all.classed('fade', function (d) { return d.data.fade })
+          all
+            .classed('fade', function (d) { return d.data.fade })
+            .attr('transform', translate)
         })
 
         time('rect', function () {
           all.select('rect')
+            .attr('width', frameWidth)
             .attr('height', function (d) { return d.data.hide ? 0 : c })
             .style('stroke', function (d) {
               if (!d.parent) return 'rgba(0,0,0,0.7)'
@@ -433,6 +424,7 @@ function flameGraph (opts) {
 
         time('text', function () {
           all.select('foreignObject')
+            .attr('width', frameWidth)
             .attr('height', function (d) { return d.data.hide ? 0 : c })
             .select('div')
               .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
 function flameGraph (opts) {
-  var tree = opts.tree 
+  var tree = opts.tree
   window.tree = tree
   var element = opts.element
   var c = 18 // cell height
@@ -231,13 +231,15 @@ function flameGraph (opts) {
     return 'translate(' + x(d.x0) + ',' + (h - (depth * c) - c) + ')'
   }
 
-  function frameWidth (d) {
-    return (d.x1 - d.x0) * w
-  }
-
   function update () {
     selection
       .each(function (data) {
+        function frameWidth (d) {
+          var rootDx = data.x1 - data.x0
+          var dx = d.x1 - d.x0
+          return dx * w / rootDx
+        }
+
         filter(data)
 
         data

--- a/index.js
+++ b/index.js
@@ -313,8 +313,8 @@ function flameGraph (opts) {
 
         node.append('foreignObject')
           .style('overflow', 'hidden')
+          .style('pointer-events', 'none')
           .append('xhtml:div')
-            .style('pointer-events', 'none')
             .style('white-space', 'nowrap')
             .style('text-overflow', 'ellipsis')
             .style('overflow', 'hidden')

--- a/index.js
+++ b/index.js
@@ -369,10 +369,13 @@ function flameGraph (opts) {
 
       augment(data)
       filter(data)
-      // "creative" fix for node ordering when partition is called for the first time
-      partition(data)
 
       // first draw
+      // goto-bus-stop: Doing this twice because the `label()` function is not
+      // called the first time? No clue why that happens but calling this twice works…
+      // Without this the <foreignObject> elements are empty etc and none of the
+      // frames are visible.
+      update()
       update()
     })
   }

--- a/index.js
+++ b/index.js
@@ -305,22 +305,39 @@ function flameGraph (opts) {
 
         node
           .append('svg:rect')
+          .style('cursor', 'pointer')
           .attr('width', frameWidth)
 
         node.append('svg:title')
+          .text(titleLabel)
 
         node.append('foreignObject')
+          .style('overflow', 'hidden')
           .append('xhtml:div')
+            .style('pointer-events', 'none')
+            .style('white-space', 'nowrap')
+            .style('text-overflow', 'ellipsis')
+            .style('overflow', 'hidden')
+            .style('font-size', '12px')
+            .style('font-family', 'Verdana')
+            .style('margin-left', '4px')
+            .style('margin-right', '4px')
+            .style('line-height', '1.5')
+            .style('padding', '0')
+            .style('font-weight', '400')
+            .style('color', '#000')
             .append(label)
 
         node.attr('width', frameWidth)
           .attr('height', function (d) { return c })
           .attr('name', function (d) { return d.data.name })
-          .attr('class', function (d) { return d.data.fade ? 'frame fade' : 'frame' })
+          .classed('frame', true)
+
+        g.select('g')
+          .classed('fade', function (d) { return d.data.fade })
 
         g.select('rect')
           .attr('height', function (d) { return d.data.hide ? 0 : c })
-          .style('cursor', 'pointer')
           .style('stroke', function (d) {
             if (!d.parent) return 'rgba(0,0,0,0.7)'
             return colorHash(d.data, 1.1, allSamples, tiers)
@@ -335,9 +352,6 @@ function flameGraph (opts) {
             return d.data.highlight ? highlightColor : colorHash(d.data, undefined, allSamples, tiers)
           })
 
-        g.select('title')
-          .text(titleLabel)
-
         g.select('foreignObject')
           .transition()
           .duration(transitionDuration)
@@ -345,22 +359,9 @@ function flameGraph (opts) {
           .attr('width', frameWidth)
 
         g.select('foreignObject')
-          .style('overflow', 'hidden')
           .attr('height', function (d) { return d.data.hide ? 0 : c })
           .select('div')
           .style('display', function (d) { return (frameWidth(d) < 35) ? 'none' : 'block' })
-          .style('pointer-events', 'none')
-          .style('white-space', 'nowrap')
-          .style('text-overflow', 'ellipsis')
-          .style('overflow', 'hidden')
-          .style('font-size', '12px')
-          .style('font-family', 'Verdana')
-          .style('margin-left', '4px')
-          .style('margin-right', '4px')
-          .style('line-height', '1.5')
-          .style('padding', '0')
-          .style('font-weight', '400')
-          .style('color', '#000')
           .style('text-align', function (d) {
             return d.parent ? 'left' : 'center'
           })

--- a/index.js
+++ b/index.js
@@ -18,6 +18,18 @@ colors.def = {h: 10, s: 66, l: 80}
 colors.js = {h: 10, s: 66, l: 80}
 colors.c = {h: 10, s: 66, l: 80}
 
+function eventPath (event) {
+  if (event.path) return event.path
+  if (event.composedPath) return event.composedPath()
+  var target = event.target
+  var path = [target]
+  while ((target = target.parentElement)) {
+    path.push(target)
+  }
+  path.push(document, window)
+  return path
+}
+
 function flameGraph (opts) {
   var tree = opts.tree
   window.tree = tree
@@ -302,7 +314,7 @@ function flameGraph (opts) {
         var g = svg.selectAll('g').data(data.descendants())
 
         svg.on('click', function (d) {
-          if (d3.event.path[0] === this) {
+          if (eventPath(d3.event)[0] === this) {
             zoom(d)
           }
         })

--- a/index.js
+++ b/index.js
@@ -240,14 +240,14 @@ function flameGraph (opts) {
           return dx * w / rootDx
         }
         function sumChildValues (a, b) {
-          return a + (b.hide ? 0 : b.value)
+          return a + (b.hide || b.fade ? 0 : b.value)
         }
 
         filter(data)
 
         data
           .sum(function (d) {
-            if (d.hide) return 0
+            if (d.fade) return d.children.reduce(sumChildValues, 0)
             const childValues = d.children
               ? d.children.reduce(sumChildValues, 0)
               : 0

--- a/index.js
+++ b/index.js
@@ -71,10 +71,10 @@ function flameGraph (opts) {
   }
   function labelStack (d) {
     if (!d.parent) return null
-    var onStack = d.data.name ? Math.round(100 * (d.data.value / allSamples), 1) + '% on stack' : ''
-    var top = stackTop(d)
+    var onStack = d.data.name ? Math.round(100 * (d.data.value / allSamples) * 10) / 10 + '% on stack' : ''
+    var top = stackTop(d.data)
     var topOfStack = d.data.name ? (top
-      ? Math.round(100 * (top / allSamples), 2) + '% stack top'
+      ? Math.round(100 * (top / allSamples) * 100) / 100 + '% stack top'
       : '') : ''
 
     if (onStack && topOfStack) { onStack += ', ' }
@@ -97,11 +97,11 @@ function flameGraph (opts) {
 
   function titleLabel (d) {
     if (!d.parent) return ''
-    var top = stackTop(d)
+    var top = stackTop(d.data)
     return d.data.name + '\n' + (top
-      ? 'Top of Stack:' + Math.round(100 * (top / allSamples), 1) + '% ' +
+      ? 'Top of Stack:' + Math.round(100 * (top / allSamples) * 10) / 10 + '% ' +
       '(' + top + ' of ' + allSamples + ' samples)\n'
-      : '') + 'On Stack:' + Math.round(100 * (d.data.value / allSamples), 1) + '% ' +
+      : '') + 'On Stack:' + Math.round(100 * (d.data.value / allSamples) * 10) / 10 + '% ' +
      '(' + d.data.value + ' of ' + allSamples + ' samples)'
   }
 

--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ function flameGraph (opts) {
     if (typeof sort === 'function') {
       return sort(a, b)
     } else if (sort) {
-      return d3.ascending(a.value.name, b.value.name)
+      return d3.ascending(a.data.name, b.data.name)
     } else {
       return 0
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "David Mark Clements <david.clements@nearform.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "d3": "^3.5.16",
+    "d3": "^5.0.0",
     "escape-string-regexp": "^1.0.5",
     "hsl-to-rgb-for-reals": "^1.1.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Flamegraph visualization for d3 v3.5.x
 ## Installation
 
 ```sh
-npm install d3-fg--save
+npm install d3-fg --save
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # d3-fg
 
-Flamegraph visualization for d3 v3.5.x
+Flamegraph visualization for d3 v5.x
 
 ## Installation
 
@@ -10,7 +10,7 @@ npm install d3-fg --save
 
 ## Usage
 
-d3-fg is currently built against [d3](http://npm.im/d3) v3.5.x.
+d3-fg is currently built against [d3](http://npm.im/d3) v5.x.
 
 ```js
 var tree = require('./data.json') // d3 json tree 


### PR DESCRIPTION
Demo: https://onerous-pencil.surge.sh/flamegraph.html

---

- Fixes zooming out to all stacks in Firefox
- Performance improvements
  - only apply constant CSS values on .enter() (could move this to CSS classes possibly for more wins)
  - remove hidden elements from the selection to reduce the amount of DOM nodes that need to be animated

---

Fixed a fair few things so it renders now, remaining issues:

 - [x] when you toggle app/deps/core/etc visibility, some of the stacks change order
 - [x] 'zooming in' on a stack does not make it larger, it just hides the rest.
       I think to fix it we have to find the lowest non-hidden frame and use its width in the `frameWidth()` calculation?
 - [x] zooming in on a stack makes it larger, but the frame you selected is not 100% wide, the frame right below is 100% wide.
 - [x] doesn't render the first time
 - [x] https://github.com/davidmarkclements/d3-fg/pull/2/commits/aa4d70887fc6ee5f032b7fc28a70a40f86e53f63 may have to be reverted—it breaks animations in non-chrome
