### PR TITLE
Node zoom API

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var rxEsc = require('escape-string-regexp')
 var d3 = Object.assign(
   {},
   require('d3-array'),
+  require('d3-dispatch'),
   require('d3-ease'),
   require('d3-hierarchy'),
   require('d3-scale'),
@@ -50,7 +51,8 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var selection = null // selection
+  var dispatch = d3.dispatch('zoom')
+  var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
   var sort = true
@@ -248,6 +250,8 @@ function flameGraph (opts) {
         update({ animate: true })
       })
     })
+
+    dispatch.call('zoom', null, d.data)
   }
 
   function searchTree (d, term, color) {
@@ -729,6 +733,16 @@ function flameGraph (opts) {
       })
     } else update()
   }
+
+  chart.zoom = (data = nodes[0].data) => {
+    // nodes[0] = root node
+    // users of this method can zoom in on a data point
+    // instead of a node.
+    const node = nodes.find(n => n.data === data)
+    zoom(node || nodes[0])
+  }
+
+  chart.on = dispatch.on.bind(dispatch)
 
   exclude.forEach(chart.typeHide)
   d3.select(element).datum(d3.hierarchy(tree, function (d) { return d.c || d.children }))

--- a/index.js
+++ b/index.js
@@ -416,10 +416,9 @@ function flameGraph (opts) {
     var x = scaleToWidth(node.x0)
 
     if (ease !== 1 && node.data.prev) {
-      var pw = frameWidth(node.data.prev)
-      var px = scaleToWidth(node.data.prev.x0)
-      width = pw + ease * (width - pw)
-      x = px + ease * (x - px)
+      var prev = node.data.prev
+      width = interpolate(frameWidth(prev), width, ease)
+      x = interpolate(scaleToWidth(prev.x0), x, ease)
     }
 
     if (width < 1) return
@@ -848,11 +847,15 @@ function createAnimation (opts, render, done) {
     currentX (node) {
       var prev = node.data.prev
       return {
-        x0: prev.x0 + ease * (node.x0 - prev.x0),
-        x1: prev.x1 + ease * (node.x1 - prev.x1)
+        x0: interpolate(prev.x0, node.x0, ease),
+        x1: interpolate(prev.x1, node.x1, ease)
       }
     }
   }
+}
+
+function interpolate (start, end, ease) {
+  return start + ease * (end - start)
 }
 
 module.exports = flameGraph

--- a/index.js
+++ b/index.js
@@ -412,7 +412,6 @@ function flameGraph (opts) {
 
     var depth = frameDepth(node)
     var width = frameWidth(node)
-    if (width < 1) return
 
     var x = scaleToWidth(node.x0)
 
@@ -422,6 +421,8 @@ function flameGraph (opts) {
       width = pw + ease * (width - pw)
       x = px + ease * (x - px)
     }
+
+    if (width < 1) return
 
     var strokeColor = node.parent ? colorHash(node.data, 1.1, allSamples, tiers) : 'rgba(0, 0, 0, 0.7)'
     var fillColor = node.parent


### PR DESCRIPTION
Adds node zooming methods.
- Do `graph.zoom(dataNode)` to zoom in on a node programmatically.
- Do `graph.on('zoom', (dataNode) => {})` to listen for node zoom changes.

This allows 0x to implement history management, like updating the
URL hash when a user zooms in on an entry and telling the graph to
zoom in on a different node when the user goes back in the browser
history.

Previously it was not possible to pick a different node while a zoom
animation was ongoing. It was not a problem because users could just
wait the few 100ms to click the next node. However, with the
programmatically controlled `graph.zoom()` function, it's feasible to
flick through nodes very quickly; eg when connected to the browser back
button. Without this patch you could end up with an outdated state
because zoom calls were ignored for 500ms.
With this patch, a zoom call mid-zoom cancels the animation and starts
a new animation. It starts it from the current, mid-animation position
as well, so it's nicely smooth! I also fixed a bug where stacks would
pop out of existence instead of animating away (they where hidden based
on their target width, instead of their current mid-animation width.)