### PR TITLE
Resize canvas and rerender after .width() or .height() call

### DIFF
--- a/index.js
+++ b/index.js
@@ -303,6 +303,10 @@ function flameGraph (opts) {
 
     var mayAnimate = opts && opts.animate
 
+    selection.select('canvas')
+      .attr('width', w)
+      .attr('height', h)
+
     selection
       .each(function (data) {
         time('filter', function () {
@@ -635,6 +639,7 @@ function flameGraph (opts) {
     if (!arguments.length) { return h }
     h = _
     onresize()
+    update()
     return chart
   }
 
@@ -642,6 +647,7 @@ function flameGraph (opts) {
     if (!arguments.length) { return w }
     w = _
     onresize()
+    update()
     return chart
   }
 


### PR DESCRIPTION
This way the canvas width is the same as the width of its contents.
It fixes an issue where making the screen larger would cut off the graph
at the old, smaller, size:
![image](https://user-images.githubusercontent.com/1006268/44148080-0c89a962-a097-11e8-8308-03d2330a57d2.png)
