### PR TITLE
Fix crash when no data was recorded

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,7 +337,7 @@ function flameGraph (opts) {
             .sort(doSort)
 
           // Make "all stacks" as wide as every visible stack.
-          data.value = data.children.reduce(sumChildValues, 0)
+          data.value = data.children ? data.children.reduce(sumChildValues, 0) : 0
         })
 
         time('partition', function () {


### PR DESCRIPTION
Previously the "all stacks" width calculation would fail if no data was recorded, because the "all stacks" frame did not have children. With this patch, it just shows an empty graph:

![image](https://user-images.githubusercontent.com/1006268/44452825-d0991a80-a5f7-11e8-97b2-60cbacc1de61.png)

This `if children ? sum : 0` check is used for all other width calculations already, I just didn't realise that the topmost frame could have no children.