### PR TITLE
Allow colorHash function to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,11 @@ function flameGraph (opts) {
   var hoverFrame = null
   var currentAnimation = null
 
+  // Use custom coloring function if one has been passed in
+  if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
+    return opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers })
+  }
+
   onresize()
 
   function onresize () {
@@ -766,6 +771,7 @@ function flameGraph (opts) {
   return chart
 }
 
+// This function can be overridden by passing a function to opts.colorHash
 function colorHash (d, perc, allSamples, tiers) {
   if (!d.name) {
     return perc ? 'rgb(127, 127, 127)' : 'rgba(0, 0, 0, 0)'

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,38 @@ d3-fg is currently built against [d3](http://npm.im/d3) v5.x.
 ```js
 var tree = require('./data.json') // d3 json tree
 var element = document.querySelector('chart') // <chart> element which should be in html body
-require('d3-flamegraph')({tree, element})
+var flamegraph = require('d3-flamegraph')({tree, element})
+```
+
+## Options
+
+Pass in options as an object:
+
+```js
+require('d3-flamegraph')({
+  // Required:
+  tree: {     // tree object like d3.hierarchy() https://github.com/d3/d3-hierarchy/#hierarchy - expects:
+    parent,   // Object reference with same schema, falsy for root node (options.tree itself)
+    children, // Array of objects with same schema, falsy for leaf nodes (nodes without children)
+    depth     // Number of ancestors in tree (position in stack from bottom), zero for root node
+  },
+  element,    // Existing DOM reference. Do not pass a d3 selection, use d3.select(...).node()
+
+  // Optional:
+  timing,     // Boolean, if passed as true logs times to console
+  height,     // Number (pixels). If not set, is calculated based on tallest stack
+  width,      // Number (pixels). If not set, is calculated based on clientWidth when called
+  colorHash: function (stackTop, options) { // Function sets each frame's RGB value. Default used if unset
+    const {
+      d,             // Object, d3 datum: one frame, one item in the tree
+      decimalAdjust, // Number, optional multiplier adjusting colour intensity up or down e.g. for borders
+      allSamples,    // Number, total summed time value (i.e. time represented by flamegraph width)
+      tiers          // Boolean, true if base color varies by frame type e.g. app vs core
+    } = options
+    stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
+    return           // String, expects valid rgb, rgba or hash string
+  }
+})
 ```
 
 ## Dependencies

--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,9 @@ npm install d3-fg --save
 d3-fg is currently built against [d3](http://npm.im/d3) v5.x.
 
 ```js
-var tree = require('./data.json') // d3 json tree 
+var tree = require('./data.json') // d3 json tree
 var element = document.querySelector('chart') // <chart> element which should be in html body
-require('d3-flamegraph')({{tree, element}})
+require('d3-flamegraph')({tree, element})
 ```
 
 ## Dependencies


### PR DESCRIPTION
Currently the colour scheme used by d3-fg is hardcoded in. This allows a colour setting function to be passed in to D3-FG as an option, so that other palettes can be used.