### PR TITLE
Add `heatBars` mode, add color options

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ function flameGraph (opts) {
   h += opts.topOffset || 0
   var w = opts.width || document.body.clientWidth * 0.89 // graph width
   var labelColors = opts.labelColors || { default: '#fff' }
+  var frameColors = opts.frameColors || { fill: '#000', stroke: '#363b4c' }
   var scaleToWidth = null
   var scaleToGraph = null
   var panZoom = d3.zoom().on('zoom', function () {
@@ -442,8 +443,8 @@ function flameGraph (opts) {
     // Draw boxes.
     context.fillStyle = node.data.highlight
         ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
-        : '#000'
-    context.strokeStyle = '#363b4c'
+        : frameColors.fill
+    context.strokeStyle = frameColors.stroke
     context.beginPath()
     context.rect(x, h - (depth * c) - c, width, c)
     if (state === STATE_HOVER) {

--- a/index.js
+++ b/index.js
@@ -444,14 +444,6 @@ function flameGraph (opts) {
       context.clearRect(x, y, width, c)
     }
 
-    // Draw boxes.
-    renderStackFrameBox(context, node, x, y, width, state)
-
-    // Draw labels.
-    if (width >= 35) {
-      renderLabel(context, node, x, y, width)
-    }
-
     // Draw heat.
     if (heatBars && node.parent != null &&
         // These states mean we're redrawing on top of an existing rendered graph,
@@ -459,6 +451,14 @@ function flameGraph (opts) {
         // still be visible from before
         (state !== STATE_HOVER && state !== STATE_UNHOVER)) {
       renderHeatBar(context, node, x, y, width)
+    }
+
+    // Draw boxes.
+    renderStackFrameBox(context, node, x, y, width, state)
+
+    // Draw labels.
+    if (width >= 35) {
+      renderLabel(context, node, x, y, width)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ var STATE_IDLE = 0
 var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
+const HEAT_HEIGHT = 10
+
 function flameGraph (opts) {
   var tree = opts.tree
   var timing = opts.timing || false
@@ -432,24 +434,17 @@ function flameGraph (opts) {
 
     if (width < 1) return
 
-    var strokeColor = node.parent ? colorHash(node.data, 1.1, allSamples, tiers) : 'rgba(0, 0, 0, 0.7)'
-    var fillColor = node.parent
-      ? (node.data.highlight
-        ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
-        : colorHash(node.data, undefined, allSamples, tiers))
-      : '#fff'
-
     if (state === STATE_HOVER || state === STATE_UNHOVER) {
       context.clearRect(x, h - (depth * c) - c, width, c)
     }
 
-    context.fillStyle = fillColor
-    context.strokeStyle = strokeColor
-
+    // Draw boxes.
+    context.fillStyle = node.data.highlight
+        ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
+        : '#000'
+    context.strokeStyle = '#363b4c'
     context.beginPath()
     context.rect(x, h - (depth * c) - c, width, c)
-    context.stroke()
-
     if (state === STATE_HOVER) {
       context.save()
       context.globalAlpha = 0.8
@@ -458,6 +453,7 @@ function flameGraph (opts) {
     } else {
       context.fill()
     }
+    context.stroke()
 
     // Draw labels.
     if (width >= 35) {
@@ -485,6 +481,26 @@ function flameGraph (opts) {
 
       context.restore()
     }
+
+    if (state === STATE_HOVER || state === STATE_UNHOVER) {
+      // Don't redraw heat, it will overlap child nodes
+      return
+    }
+
+    // Draw heat.
+    var strokeColor = node.parent
+      ? colorHash(node.data, 1.1, allSamples, tiers)
+      : 'rgba(0, 0, 0, 0.7)'
+    var heatColor = node.parent
+      ? colorHash(node.data, undefined, allSamples, tiers)
+      : '#000'
+
+    context.fillStyle = heatColor
+    context.strokeStyle = strokeColor
+    context.beginPath()
+    context.rect(x, h - (depth * c) - c - HEAT_HEIGHT, width, HEAT_HEIGHT)
+    context.fill()
+    context.beginPath()
   }
 
   function renderTooltip (node) {

--- a/index.js
+++ b/index.js
@@ -471,14 +471,17 @@ function flameGraph (opts) {
         labelOffset = width / 2
       }
 
+      // Magic value to sorta kinda align the label in the middle of the frame height
+      // It's not very accurate
+      var btmOffset = Math.floor((c - 16) / 2)
       var label = labelName(node)
-      context.fillText(label, x + labelOffset, h - (depth * c) - 1)
+      context.fillText(label, x + labelOffset, h - (depth * c) - btmOffset + 2)
 
       var stack = labelStack(node)
       if (stack) {
         var nameWidth = context.measureText(label + ' ').width
         context.font = `12px ${FONT_FAMILY}`
-        context.fillText(stack, x + labelOffset + nameWidth, h - (depth * c) - 2)
+        context.fillText(stack, x + labelOffset + nameWidth, h - (depth * c) - btmOffset)
       }
 
       context.restore()

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var STATE_IDLE = 0
 var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
-const HEAT_HEIGHT = 10
+const HEAT_HEIGHT = 5
 const FONT_FAMILY = 'Verdana, sans-serif'
 
 function flameGraph (opts) {

--- a/index.js
+++ b/index.js
@@ -488,14 +488,14 @@ function flameGraph (opts) {
       // Don't redraw heat, it will overlap child nodes
       return
     }
+    if (!node.parent) {
+      // Root "all stacks" node doesn't have a heat
+      return
+    }
 
     // Draw heat.
-    var strokeColor = node.parent
-      ? colorHash(node.data, 1.1, allSamples, tiers)
-      : 'rgba(0, 0, 0, 0.7)'
-    var heatColor = node.parent
-      ? colorHash(node.data, undefined, allSamples, tiers)
-      : '#000'
+    var strokeColor = colorHash(node.data, 1.1, allSamples, tiers)
+    var heatColor = colorHash(node.data, undefined, allSamples, tiers)
 
     context.fillStyle = heatColor
     context.strokeStyle = strokeColor

--- a/index.js
+++ b/index.js
@@ -457,7 +457,7 @@ function flameGraph (opts) {
         // These states mean we're redrawing on top of an existing rendered graph,
         // so we shouldn't exceed the current rectangle's boundaries; the heat will
         // still be visible from before
-        (state !== STATE_HOVER && state === STATE_UNHOVER)) {
+        (state !== STATE_HOVER && state !== STATE_UNHOVER)) {
       renderHeatBar(context, node, x, y, width)
     }
   }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
 const HEAT_HEIGHT = 5
-const FONT_FAMILY = 'Verdana, sans-serif'
 
 function flameGraph (opts) {
   var tree = opts.tree
@@ -70,6 +69,9 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
+
+  var fontFamily = getComputedStyle(element)
+    .getPropertyValue('font-family')
 
   // Use custom coloring function if one has been passed in
   if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
@@ -502,7 +504,7 @@ function flameGraph (opts) {
     context.beginPath()
     context.rect(x, y, width, c)
     context.clip()
-    context.font = c > 20 ? `16px ${FONT_FAMILY}` : `12px ${FONT_FAMILY}`
+    context.font = c > 20 ? `16px ${fontFamily}` : `12px ${fontFamily}`
     context.fillStyle = labelColors[node.data.type] || labelColors.default
 
     var labelOffset = 4 // padding
@@ -521,7 +523,7 @@ function flameGraph (opts) {
     var stack = labelStack(node)
     if (stack) {
       var nameWidth = context.measureText(label + ' ').width
-      context.font = c > 20 ? `12px ${FONT_FAMILY}` : `10px ${FONT_FAMILY}`
+      context.font = c > 20 ? `12px ${fontFamily}` : `10px ${fontFamily}`
       context.fillText(stack, x + labelOffset + nameWidth, y + c - btmOffset)
     }
 

--- a/index.js
+++ b/index.js
@@ -484,7 +484,17 @@ function flameGraph (opts) {
     } else {
       context.fill()
     }
-    context.stroke()
+
+    if (heatBars) {
+      context.beginPath()
+      context.moveTo(x, y)
+      context.lineTo(x, y + c)
+      context.moveTo(x + width, y)
+      context.lineTo(x + width, y + c)
+      context.stroke()
+    } else {
+      context.stroke()
+    }
   }
 
   function renderLabel (context, node, x, y, width) {

--- a/index.js
+++ b/index.js
@@ -445,7 +445,7 @@ function flameGraph (opts) {
     }
 
     // Draw boxes.
-    renderStackFrameBox(context, node, x, y, width)
+    renderStackFrameBox(context, node, x, y, width, state)
 
     // Draw labels.
     if (width >= 35) {
@@ -462,7 +462,7 @@ function flameGraph (opts) {
     }
   }
 
-  function renderStackFrameBox (context, node, x, y, width) {
+  function renderStackFrameBox (context, node, x, y, width, state) {
     var fillColor = heatBars || !node.parent
       ? frameColors.fill
       : colorHash(node.data, undefined, allSamples, tiers)

--- a/index.js
+++ b/index.js
@@ -497,11 +497,19 @@ function flameGraph (opts) {
   }
 
   function renderLabel (context, node, x, y, width) {
+    // baseline size of 12px—for every ~3px that cellHeight grows above its baseline of 18px,
+    // grow the font size 1px
+    // This way the font size gets relatively smaller, giving it some breathing room at larger cell heights
+    // while also being readable at small cell heights
+    // NOTE this currently does NOT deal with cell heights below 18px, but then nothing in d3-fg really does
+    var labelFontSize = Math.floor(12 + (c - 18) * 0.3)
+    var stackFontSize = Math.floor(labelFontSize * 10 / 12)
+
     context.save()
     context.beginPath()
     context.rect(x, y, width, c)
     context.clip()
-    context.font = c > 20 ? `16px ${FONT_FAMILY}` : `12px ${FONT_FAMILY}`
+    context.font = `${labelFontSize}px ${FONT_FAMILY}`
     context.fillStyle = labelColors[node.data.type] || labelColors.default
 
     var labelOffset = 4 // padding
@@ -520,7 +528,7 @@ function flameGraph (opts) {
     var stack = labelStack(node)
     if (stack) {
       var nameWidth = context.measureText(label + ' ').width
-      context.font = c > 20 ? `12px ${FONT_FAMILY}` : `10px ${FONT_FAMILY}`
+      context.font = `${stackFontSize}px ${FONT_FAMILY}`
       context.fillText(stack, x + labelOffset + nameWidth, y + c - btmOffset)
     }
 

--- a/index.js
+++ b/index.js
@@ -36,6 +36,8 @@ var STATE_IDLE = 0
 var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
+var FONT_FAMILY = 'Verdana, sans-serif'
+
 function flameGraph (opts) {
   var tree = opts.tree
   var timing = opts.timing || false
@@ -67,9 +69,6 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
-
-  var fontFamily = getComputedStyle(element)
-    .getPropertyValue('font-family')
 
   // Use custom coloring function if one has been passed in
   if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
@@ -502,7 +501,7 @@ function flameGraph (opts) {
     context.beginPath()
     context.rect(x, y, width, c)
     context.clip()
-    context.font = c > 20 ? `16px ${fontFamily}` : `12px ${fontFamily}`
+    context.font = c > 20 ? `16px ${FONT_FAMILY}` : `12px ${FONT_FAMILY}`
     context.fillStyle = labelColors[node.data.type] || labelColors.default
 
     var labelOffset = 4 // padding
@@ -521,7 +520,7 @@ function flameGraph (opts) {
     var stack = labelStack(node)
     if (stack) {
       var nameWidth = context.measureText(label + ' ').width
-      context.font = c > 20 ? `12px ${fontFamily}` : `10px ${fontFamily}`
+      context.font = c > 20 ? `12px ${FONT_FAMILY}` : `10px ${FONT_FAMILY}`
       context.fillText(stack, x + labelOffset + nameWidth, y + c - btmOffset)
     }
 

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function flameGraph (opts) {
   var tree = opts.tree
   var timing = opts.timing || false
   var element = opts.element
-  var c = 18 // cell height
+  var c = 35 // cell height
   var h = opts.height || (maxDepth(tree) + 2) * c // graph height
   var minHeight = opts.minHeight || 950
   h = h < minHeight ? minHeight : h
@@ -459,28 +459,28 @@ function flameGraph (opts) {
       context.fill()
     }
 
+    // Draw labels.
     if (width >= 35) {
       context.save()
       context.clip()
-      context.font = '12px Verdana'
-      context.fillStyle = '#000'
+      context.font = '16px Verdana'
+      context.fillStyle = '#fff'
 
+      var labelOffset = 4 // padding
       // Center the "all stacks" text
       if (!node.parent) {
         context.textAlign = 'center'
-        x += width / 2
-      } else {
-        x += 4 // add padding to other nodes
+        labelOffset = width / 2
       }
 
       var label = labelName(node)
-      context.fillText(label, x, h - (depth * c) - 1)
+      context.fillText(label, x + labelOffset, h - (depth * c) - 1)
 
       var stack = labelStack(node)
       if (stack) {
-        var offs = context.measureText(label + ' ').width
-        context.font = '10px Verdana'
-        context.fillText(stack, x + offs, h - (depth * c) - 2)
+        var nameWidth = context.measureText(label + ' ').width
+        context.font = '12px Verdana'
+        context.fillText(stack, x + labelOffset + nameWidth, h - (depth * c) - 2)
       }
 
       context.restore()

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
 const HEAT_HEIGHT = 10
+const FONT_FAMILY = 'Verdana, sans-serif'
 
 function flameGraph (opts) {
   var tree = opts.tree
@@ -382,7 +383,6 @@ function flameGraph (opts) {
         function render (canvas, nodes, ease) {
           if (ease == null) ease = 1
           var context = canvas.getContext('2d')
-          context.font = '12px Verdana, sans-serif'
           context.textBaseline = 'bottom'
 
           context.clearRect(0, 0, canvas.width, canvas.height)
@@ -461,7 +461,7 @@ function flameGraph (opts) {
     if (width >= 35) {
       context.save()
       context.clip()
-      context.font = '16px Verdana'
+      context.font = `16px ${FONT_FAMILY}`
       context.fillStyle = labelColors[node.data.type] || labelColors.default
 
       var labelOffset = 4 // padding
@@ -477,7 +477,7 @@ function flameGraph (opts) {
       var stack = labelStack(node)
       if (stack) {
         var nameWidth = context.measureText(label + ' ').width
-        context.font = '12px Verdana'
+        context.font = `12px ${FONT_FAMILY}`
         context.fillText(stack, x + labelOffset + nameWidth, h - (depth * c) - 2)
       }
 

--- a/index.js
+++ b/index.js
@@ -473,6 +473,7 @@ function flameGraph (opts) {
         ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
         : fillColor
     context.strokeStyle = strokeColor
+
     context.beginPath()
     context.rect(x, y, width, c)
     if (state === STATE_HOVER) {
@@ -488,6 +489,8 @@ function flameGraph (opts) {
 
   function renderLabel (context, node, x, y, width) {
     context.save()
+    context.beginPath()
+    context.rect(x, y, width, c)
     context.clip()
     context.font = c > 20 ? `16px ${FONT_FAMILY}` : `12px ${FONT_FAMILY}`
     context.fillStyle = labelColors[node.data.type] || labelColors.default

--- a/index.js
+++ b/index.js
@@ -36,8 +36,6 @@ var STATE_IDLE = 0
 var STATE_HOVER = 1
 var STATE_UNHOVER = 2
 
-const HEAT_HEIGHT = 5
-
 function flameGraph (opts) {
   var tree = opts.tree
   var timing = opts.timing || false
@@ -533,11 +531,12 @@ function flameGraph (opts) {
   function renderHeatBar (context, node, x, y, width) {
     var heatColor = colorHash(node.data, undefined, allSamples, tiers)
     var heatStrokeColor = colorHash(node.data, 1.1, allSamples, tiers)
+    var heatHeight = Math.floor(c / 3)
 
     context.fillStyle = heatColor
     context.strokeStyle = heatStrokeColor
     context.beginPath()
-    context.rect(x, y - HEAT_HEIGHT, width, HEAT_HEIGHT)
+    context.rect(x, y - heatHeight, width, heatHeight)
     context.fill()
     context.stroke()
   }

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function flameGraph (opts) {
   h = h < minHeight ? minHeight : h
   h += opts.topOffset || 0
   var w = opts.width || document.body.clientWidth * 0.89 // graph width
+  var labelColors = opts.labelColors || { default: '#fff' }
   var scaleToWidth = null
   var scaleToGraph = null
   var panZoom = d3.zoom().on('zoom', function () {
@@ -460,7 +461,7 @@ function flameGraph (opts) {
       context.save()
       context.clip()
       context.font = '16px Verdana'
-      context.fillStyle = '#fff'
+      context.fillStyle = labelColors[node.data.type] || labelColors.default
 
       var labelOffset = 4 // padding
       // Center the "all stacks" text

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,9 @@ require('d3-flamegraph')({
   timing,     // Boolean, if passed as true logs times to console
   categorizer: function (data, index, children) { // Function that determines the category for a given
                                                   // stack frame. e.g. "app", "core"
-    return // String, indicates the category
+    return {
+      type // String, indicates the category
+    }
   }
   height,     // Number (pixels). If not set, is calculated based on tallest stack
   width,      // Number (pixels). If not set, is calculated based on clientWidth when called

--- a/readme.md
+++ b/readme.md
@@ -39,20 +39,20 @@ require('d3-flamegraph')({
   colorHash: function (stackTop, options) { // Function sets each frame's RGB value. Default used if unset
     const {
       d,             // Object, d3 datum: one frame, one item in the tree
-      decimalAdjust, // Number, optional multiplier adjusting colour intensity up or down e.g. for borders
+      decimalAdjust, // Number, optional multiplier adjusting color intensity up or down e.g. for borders
       allSamples,    // Number, total summed time value (i.e. time represented by flamegraph width)
       tiers          // Boolean, true if base color varies by frame type e.g. app vs core
     } = options
     stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
     return           // String, expects valid rgb, rgba or hash string
   },
-  frameColors: { // Object, colours for the stack frame boxes
-    fill: '#000', // String, background colour.
-    stroke: '#363b4c', // String, border colour.
+  frameColors: { // Object, colors for the stack frame boxes
+    fill: '#000', // String, background color.
+    stroke: '#363b4c', // String, border color.
   },
-  labelColors: { // Object, colours for the text labels on stack frames
-    default: '#fff', // String, the default colour (required).
-    [categoryName]: 'color', // Optionally, colours for different categories such as "app", "cpp".
+  labelColors: { // Object, colors for the text labels on stack frames
+    default: '#fff', // String, the default color (required).
+    [categoryName]: 'color', // Optionally, colors for different categories such as "app", "cpp".
                              // If one of these is not set for a category, labelColors.default is used
   }
 })

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,11 @@ require('d3-flamegraph')({
     } = options
     stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
     return           // String, expects valid rgb, rgba or hash string
+  },
+  labelColors: { // Object, colours for the text labels on stack frames
+    default: '#fff', // String, the default colour (required).
+    [categoryName]: 'color', // Optionally, colours for different categories such as "app", "cpp".
+                             // If one of these is not set for a category, labelColors.default is used
   }
 })
 ```

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ require('d3-flamegraph')({
   timing,     // Boolean, if passed as true logs times to console
   height,     // Number (pixels). If not set, is calculated based on tallest stack
   width,      // Number (pixels). If not set, is calculated based on clientWidth when called
+  cellHeight, // Number (pixels). Defaults to 18 pixels. Font sizes scale along with this value.
   colorHash: function (stackTop, options) { // Function sets each frame's RGB value. Default used if unset
     const {
       d,             // Object, d3 datum: one frame, one item in the tree
@@ -46,14 +47,16 @@ require('d3-flamegraph')({
     stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
     return           // String, expects valid rgb, rgba or hash string
   },
-  frameColors: { // Object, colors for the stack frame boxes
-    fill: '#000', // String, background color.
-    stroke: '#363b4c', // String, border color.
+  heatBars, // Boolean, when false (the default), heat is visualized as the background colour of stack frames; when true, heat is visualized by a bar drawn on _top_ of stack frames
+  frameColors: { // Object, colors for the stack frame boxes.
+                 // Used when `heatBars: true`, and for the "all stacks" row when `heatBars: false`
+    fill,   // String, background color.
+    stroke, // String, border color.
   },
   labelColors: { // Object, colors for the text labels on stack frames
-    default: '#fff', // String, the default color (required).
-    [categoryName]: 'color', // Optionally, colors for different categories such as "app", "cpp".
-                             // If one of these is not set for a category, labelColors.default is used
+    default,        // String, the default color (required).
+    [categoryName], // Optionally, colors for different categories such as "app", "cpp".
+                    // If one of these is not set for a category, labelColors.default is used
   }
 })
 ```

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,10 @@ require('d3-flamegraph')({
     stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
     return           // String, expects valid rgb, rgba or hash string
   },
+  frameColors: { // Object, colours for the stack frame boxes
+    fill: '#000', // String, background colour.
+    stroke: '#363b4c', // String, border colour.
+  },
   labelColors: { // Object, colours for the text labels on stack frames
     default: '#fff', // String, the default colour (required).
     [categoryName]: 'color', // Optionally, colours for different categories such as "app", "cpp".

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ require('d3-flamegraph')({
 
   // Optional:
   timing,     // Boolean, if passed as true logs times to console
+  categorizer: function (data, index, children) { // Function that determines the category for a
+                                                  // given stack frame. e.g. "app", "core"
+    return // String, indicates the category
+  }
   height,     // Number (pixels). If not set, is calculated based on tallest stack
   width,      // Number (pixels). If not set, is calculated based on clientWidth when called
   cellHeight, // Number (pixels). Defaults to 18 pixels. Font sizes scale along with this value.

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ require('d3-flamegraph')({
 
   // Optional:
   timing,     // Boolean, if passed as true logs times to console
-  categorizer: function (data, index, children) { // Function that determines the category for a
-                                                  // given stack frame. e.g. "app", "core"
+  categorizer: function (data, index, children) { // Function that determines the category for a given
+                                                  // stack frame. e.g. "app", "core"
     return // String, indicates the category
   }
   height,     // Number (pixels). If not set, is calculated based on tallest stack
@@ -51,7 +51,8 @@ require('d3-flamegraph')({
     stackTop(d)      // Returns number representing time in this frame not in any non-hidden child frames
     return           // String, expects valid rgb, rgba or hash string
   },
-  heatBars, // Boolean, when false (the default), heat is visualized as the background colour of stack frames; when true, heat is visualized by a bar drawn on _top_ of stack frames
+  heatBars, // Boolean, when false (the default), heat is visualized as the background colour of stack frames;
+            // when true, heat is visualized by a bar drawn on _top_ of stack frames
   frameColors: { // Object, colors for the stack frame boxes.
                  // Used when `heatBars: true`, and for the "all stacks" row when `heatBars: false`
     fill,   // String, background color.


### PR DESCRIPTION
This adds a `heatBars` option that, when set to `true`, causes d3-fg to draw the heat colour in a bar on _top_ of each stack frame. When `false`, it still draws the heat colour as the background colour of the stack frame.

Additionally, this patch adds the following styling options:

 - `frameColors` - a `{fill, stroke}` object. If heatBars mode is enabled, this will determine the fill and stroke style for all stack frames. If heatBars mode is disabled, it will only be used for the "all stacks" pseudo-frame at the bottom.
 - `labelColors` - an object containing label text colors. The keys are type names like "app", "deps", "core", and values are the colors that should be used for labels on the stack frames of that type. `labelColors.default` is used if a color is not configured for a given type.
 - `cellHeight` - complements the `chart.cellHeight(n)` function—now you can set a custom cell height before the first render

Running 0x with these changes:

https://187100x-scbwgqrzua.now.sh/flamegraph
![image](https://user-images.githubusercontent.com/1006268/46410551-85574900-c719-11e8-8a39-71b6eccdc89b.png)

Running Clinic Flame, passing some additional style settings, with these changes:

https://upload.clinicjs.org/public/8d95dd6643e2473f71adf9343d972b403effd92cb81347e37b1a862f5b9ea4ba/12267.clinic-flame.html
![image](https://user-images.githubusercontent.com/1006268/46410887-8dfc4f00-c71a-11e8-8c0c-5e90edfed0f1.png)

(intended to be an initial handwavey approximation of the designs, not a final polished attempt)

```js
fg({
  cellHeight: 35,
  heatBars: true,
  frameColors: {
    fill: '#000',
    stroke: '#363b4c'
  },
  labelColors: {
    default: '#fff',
    app: '#cde3ff',
    core: '#626467',
    deps: '#3f7dc6'
  }
})
```

Most likely needs some tweaking still!  cc @AlanSl 