### PR TITLE
Adding support for custom tooltip

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom','hoverin','hoverout')
+  var dispatch = d3.dispatch('zoom','hoverin','hoverout', 'animationEnd')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -373,6 +373,7 @@ function flameGraph (opts) {
           }, () => {
             currentAnimation = null
             saveAnimationStartingPoints()
+            dispatch.call('animationEnd')
           })
         }
 
@@ -540,12 +541,12 @@ function flameGraph (opts) {
   // Wait for 500 ms before showing the tooltip.
   var tooltipFocusNode = null
   var tooltipFocusTimeout = null
-  var hoverin = false
+  var hoveringIn = false
   function showTooltip (node) {
 
     //let's dispatch the hover event with no delay
     dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
-    hoverin = true
+    hoveringIn = true
     if(noTooltip) return
 
     if (tooltipFocusNode === node) {
@@ -559,9 +560,9 @@ function flameGraph (opts) {
   }
 
   function hideTooltip () {
-    if(hoverin == true){
+    if(hoveringIn){
       dispatch.call('hoverout', null, null)
-      hoverin = false
+      hoveringIn = false
     }
     
     if(noTooltip) return

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom')
+  var dispatch = d3.dispatch('zoom','hoverin','hoverout')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -64,6 +64,7 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
+  var noTooltip = opts.noTooltip || false
 
   // Use custom coloring function if one has been passed in
   if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
@@ -487,6 +488,21 @@ function flameGraph (opts) {
     }
   }
 
+  function getNodeRect(node){
+    var wrapper = d3.select(element)
+    var canvas = wrapper.select('canvas').node()
+    var transform = d3.zoomTransform(canvas)
+    const x0 = transform.applyX(scaleToWidth(node.x0))
+    const x1 = transform.applyX(scaleToWidth(node.x1))
+
+    return {
+      x: x0,
+      y: transform.applyY(h - frameDepth(node) * c) - wrapper.node().scrollTop,
+      w: x1 - x0,
+      h: c
+    }
+  }
+
   function renderTooltip (node) {
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
@@ -524,7 +540,14 @@ function flameGraph (opts) {
   // Wait for 500 ms before showing the tooltip.
   var tooltipFocusNode = null
   var tooltipFocusTimeout = null
+  var hoverin = false
   function showTooltip (node) {
+
+    //let's dispatch the hover event with no delay
+    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
+    hoverin = true
+    if(noTooltip) return
+
     if (tooltipFocusNode === node) {
       return renderTooltip(node)
     }
@@ -536,6 +559,13 @@ function flameGraph (opts) {
   }
 
   function hideTooltip () {
+    if(hoverin == true){
+      dispatch.call('hoverout', null, null)
+      hoverin = false
+    }
+    
+    if(noTooltip) return
+
     clearTimeout(tooltipFocusTimeout)
     tooltipFocusNode = null
     tooltipFocusTimeout = setTimeout(function () {
@@ -616,18 +646,21 @@ function flameGraph (opts) {
             this.style.cursor = 'default'
             hideTooltip()
           })
-        node.append('div')
-          .style('background', '#222')
-          .style('color', '#fff')
-          .style('border-radius', '3px')
-          .style('padding', '3px')
-          .style('font-size', '10pt')
-          .style('position', 'fixed')
-          .style('display', 'none')
-          .style('z-index', 1000)
-          .classed('d3-flame-graph-tooltip', true)
-          .on('mouseover', preventHideTooltip)
-          .on('mouseout', hideTooltip)
+
+        if(noTooltip == false){
+          node.append('div')
+            .style('background', '#222')
+            .style('color', '#fff')
+            .style('border-radius', '3px')
+            .style('padding', '3px')
+            .style('font-size', '10pt')
+            .style('position', 'fixed')
+            .style('display', 'none')
+            .style('z-index', 1000)
+            .classed('d3-flame-graph-tooltip', true)
+            .on('mouseover', preventHideTooltip)
+            .on('mouseout', hideTooltip)
+        }
 
         // Adjust canvas for high DPI screens
         // - Size the image up N× using attributes

--- a/index.js
+++ b/index.js
@@ -545,7 +545,8 @@ function flameGraph (opts) {
   function showTooltip (node) {
 
     //let's dispatch the hover event with no delay
-    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
+    const pointerCoords = {x: d3.event.offsetX, y: d3.event.offsetY}
+    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node), pointerCoords})
     hoveringIn = true
     if(noTooltip) return
 


### PR DESCRIPTION
**DO NOT MERGE**: this PR is replaced by [THIS ONE](https://github.com/davidmarkclements/d3-fg/pull/15)
_Im leaving this here to keep track of the comments until the other PR gets merged_

This PR adds:
- the `noTooltip` option (defaults to false) to prevent the default tooltip from showing up.
- `hoverin` and `hoverout` events, triggered when the mouse enters/leaves a node
- `animationEnd` event fired at the end of the zoom animation

The two hover events pass the hovered node. This object now has also the `rect` attribute (containing the size and position of the hovered node) and `pointerCoords` containing the position of the pointer when the click occurred.
