### PR TITLE
Feature/custom tooltip

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom','hoverin','hoverout')
+  var dispatch = d3.dispatch('zoom','hoverin','hoverout', 'animationEnd')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -378,6 +378,7 @@ function flameGraph (opts) {
           }, () => {
             currentAnimation = null
             saveAnimationStartingPoints()
+            dispatch.call('animationEnd')
           })
         }
 
@@ -601,12 +602,12 @@ function flameGraph (opts) {
   // Wait for 500 ms before showing the tooltip.
   var tooltipFocusNode = null
   var tooltipFocusTimeout = null
-  var hoverin = false
+  var hoveringIn = false
   function showTooltip (node) {
 
     //let's dispatch the hover event with no delay
     dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
-    hoverin = true
+    hoveringIn = true
     if(noTooltip) return
 
     if (tooltipFocusNode === node) {
@@ -620,9 +621,9 @@ function flameGraph (opts) {
   }
 
   function hideTooltip () {
-    if(hoverin == true){
+    if(hoveringIn){
       dispatch.call('hoverout', null, null)
-      hoverin = false
+      hoveringIn = false
     }
     
     if(noTooltip) return

--- a/index.js
+++ b/index.js
@@ -563,7 +563,7 @@ function flameGraph (opts) {
 
     return {
       x: x0,
-      y: transform.applyY(h - frameDepth(node) * c) - wrapper.node().scrollTop,
+      y: transform.applyY(h - frameDepth(node) * c),
       w: x1 - x0,
       h: c
     }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom','hoverin','hoverout', 'animationEnd')
+  var dispatch = d3.dispatch('zoom', 'hoverin', 'hoverout', 'animationEnd')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -69,11 +69,15 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
-  var noTooltip = opts.noTooltip || false
+
+  // Use custom tooltip rendering function if defined
+  renderTooltip = opts.renderTooltip === undefined ? renderTooltip : node => { opts.renderTooltip && opts.renderTooltip(node) }
 
   // Use custom coloring function if one has been passed in
-  if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
-    return opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers })
+  if (opts.colorHash) {
+    colorHash = (d, decimalAdjust, allSamples, tiers) => {
+      return opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers })
+    }
   }
 
   onresize()
@@ -417,7 +421,7 @@ function flameGraph (opts) {
         : node
       node.data.prev = {
         x0: pts.x0,
-        x1: pts.x1,
+        x1: pts.x1
       }
     })
   }
@@ -550,7 +554,7 @@ function flameGraph (opts) {
     context.stroke()
   }
 
-  function getNodeRect(node){
+  function getNodeRect (node) {
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
     var transform = d3.zoomTransform(canvas)
@@ -604,12 +608,10 @@ function flameGraph (opts) {
   var tooltipFocusTimeout = null
   var hoveringIn = false
   function showTooltip (node) {
-
-    //let's dispatch the hover event with no delay
+    // let's dispatch the hover event with no delay
     const pointerCoords = {x: d3.event.offsetX, y: d3.event.offsetY}
-    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node), pointerCoords})
+    dispatch.call('hoverin', null, node.data, getNodeRect(node), pointerCoords)
     hoveringIn = true
-    if(noTooltip) return
 
     if (tooltipFocusNode === node) {
       return renderTooltip(node)
@@ -622,12 +624,10 @@ function flameGraph (opts) {
   }
 
   function hideTooltip () {
-    if(hoveringIn){
+    if (hoveringIn) {
       dispatch.call('hoverout', null, null)
       hoveringIn = false
     }
-    
-    if(noTooltip) return
 
     clearTimeout(tooltipFocusTimeout)
     tooltipFocusNode = null
@@ -710,7 +710,7 @@ function flameGraph (opts) {
             hideTooltip()
           })
 
-        if(noTooltip == false){
+        if (opts.renderTooltip !== null) {
           node.append('div')
             .style('background', '#222')
             .style('color', '#fff')

--- a/index.js
+++ b/index.js
@@ -69,14 +69,14 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
+  var coloringFunction = colorHash
+
+  // Use custom coloring function if one has been passed in
+  if (opts.colorHash !== undefined) coloringFunction = (d, decimalAdjust, allSamples, tiers) => 
+    opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
   // Use custom tooltip rendering function if defined
   if (opts.renderTooltip !== undefined) renderTooltip = node => opts.renderTooltip && opts.renderTooltip(node)
-
-  // Use custom coloring function if one has been passed in
-  if (opts.colorHash !== undefined) colorHash = (d, decimalAdjust, allSamples, tiers) => 
-    opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
-  
 
   onresize()
 
@@ -468,10 +468,10 @@ function flameGraph (opts) {
   function renderStackFrameBox (context, node, x, y, width, state) {
     var fillColor = heatBars || !node.parent
       ? frameColors.fill
-      : colorHash(node.data, undefined, allSamples, tiers)
+      : coloringFunction(node.data, undefined, allSamples, tiers)
     var strokeColor = heatBars || !node.parent
       ? frameColors.stroke
-      : colorHash(node.data, 1.1, allSamples, tiers)
+      : coloringFunction(node.data, 1.1, allSamples, tiers)
     context.fillStyle = node.data.highlight
         ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
         : fillColor
@@ -540,8 +540,8 @@ function flameGraph (opts) {
   }
 
   function renderHeatBar (context, node, x, y, width) {
-    var heatColor = colorHash(node.data, undefined, allSamples, tiers)
-    var heatStrokeColor = colorHash(node.data, 1.1, allSamples, tiers)
+    var heatColor = coloringFunction(node.data, undefined, allSamples, tiers)
+    var heatStrokeColor = coloringFunction(node.data, 1.1, allSamples, tiers)
     var heatHeight = Math.floor(c / 3)
 
     context.fillStyle = heatColor

--- a/index.js
+++ b/index.js
@@ -117,7 +117,6 @@ function flameGraph (opts) {
     return onStack + topOfStack
   }
 
-  // this function seems to be unused... shall we remove it?
   function tooltipLabel (d) {
     if (!d.parent) return ''
     var top = stackTop(d.data)

--- a/index.js
+++ b/index.js
@@ -606,7 +606,8 @@ function flameGraph (opts) {
   function showTooltip (node) {
 
     //let's dispatch the hover event with no delay
-    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
+    const pointerCoords = {x: d3.event.offsetX, y: d3.event.offsetY}
+    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node), pointerCoords})
     hoveringIn = true
     if(noTooltip) return
 

--- a/index.js
+++ b/index.js
@@ -18,19 +18,19 @@ Object.defineProperty(d3, 'event', {
 
 var diffScale = d3.scaleLinear().range([0, 0.2])
 var colors = {
-  v8: {h: 67, s: 81, l: 65},
-  inlinable: {h: 300, s: 100, l: 50},
-  regexp: {h: 27, s: 100, l: 50},
-  cpp: {h: 0, s: 50, l: 50},
-  native: {h: 122, s: 50, l: 45},
-  core: {h: 0, s: 0, l: 80},
-  deps: {h: 244, s: 50, l: 65},
-  app: {h: 200, s: 50, l: 45},
-  init: {h: 21, s: 81, l: 73}
+  v8: { h: 67, s: 81, l: 65 },
+  inlinable: { h: 300, s: 100, l: 50 },
+  regexp: { h: 27, s: 100, l: 50 },
+  cpp: { h: 0, s: 50, l: 50 },
+  native: { h: 122, s: 50, l: 45 },
+  core: { h: 0, s: 0, l: 80 },
+  deps: { h: 244, s: 50, l: 65 },
+  app: { h: 200, s: 50, l: 45 },
+  init: { h: 21, s: 81, l: 73 }
 }
-colors.def = {h: 10, s: 66, l: 80}
-colors.js = {h: 10, s: 66, l: 80}
-colors.c = {h: 10, s: 66, l: 80}
+colors.def = { h: 10, s: 66, l: 80 }
+colors.js = { h: 10, s: 66, l: 80 }
+colors.c = { h: 10, s: 66, l: 80 }
 
 var STATE_IDLE = 0
 var STATE_HOVER = 1
@@ -69,14 +69,12 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
-  var coloringFunction = colorHash
 
   // Use custom coloring function if one has been passed in
-  if (opts.colorHash !== undefined) coloringFunction = (d, decimalAdjust, allSamples, tiers) => 
-    opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
+  var colorHash = (opts.colorHash !== undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
   // Use custom tooltip rendering function if defined
-  if (opts.renderTooltip !== undefined) renderTooltip = node => opts.renderTooltip && opts.renderTooltip(node)
+  var renderTooltip = (opts.renderTooltip !== undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
   onresize()
 
@@ -119,6 +117,7 @@ function flameGraph (opts) {
     return onStack + topOfStack
   }
 
+  // this function seems to be unused... shall we remove it?
   function tooltipLabel (d) {
     if (!d.parent) return ''
     var top = stackTop(d.data)
@@ -136,23 +135,23 @@ function flameGraph (opts) {
     if (!/.js/.test(name)) {
       switch (true) {
         case /^Builtin:|^Stub:|v8::|^(.+)IC:|^.*Handler:/
-          .test(name): return {type: 'v8'}
+          .test(name): return { type: 'v8' }
         case /^RegExp:/
-          .test(name): return {type: 'regexp'}
+          .test(name): return { type: 'regexp' }
         case /apply$|call$|Arguments$/
-          .test(name): return {type: 'native'}
-        case /\.$/.test(name): return {type: 'core'}
-        default: return {type: 'cpp'}
+          .test(name): return { type: 'native' }
+        case /\.$/.test(name): return { type: 'core' }
+        default: return { type: 'cpp' }
       }
     }
 
-    if (/\[INIT\]/.test(name)) return {type: 'init'}
+    if (/\[INIT\]/.test(name)) return { type: 'init' }
 
     switch (true) {
-      case / native /.test(name): return {type: 'native'}
-      case (name.indexOf('/') === -1 || /internal\//.test(name) && !/ \//.test(name)): return {type: 'core'}
-      case !/node_modules/.test(name): return {type: 'app'}
-      default: return {type: 'deps'}
+      case / native /.test(name): return { type: 'native' }
+      case (name.indexOf('/') === -1 || /internal\//.test(name) && !/ \//.test(name)): return { type: 'core' }
+      case !/node_modules/.test(name): return { type: 'app' }
+      default: return { type: 'deps' }
     }
   }
 
@@ -468,13 +467,13 @@ function flameGraph (opts) {
   function renderStackFrameBox (context, node, x, y, width, state) {
     var fillColor = heatBars || !node.parent
       ? frameColors.fill
-      : coloringFunction(node.data, undefined, allSamples, tiers)
+      : colorHash(node.data, undefined, allSamples, tiers)
     var strokeColor = heatBars || !node.parent
       ? frameColors.stroke
-      : coloringFunction(node.data, 1.1, allSamples, tiers)
+      : colorHash(node.data, 1.1, allSamples, tiers)
     context.fillStyle = node.data.highlight
-        ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
-        : fillColor
+      ? (typeof node.data.highlight === 'string' ? node.data.highlight : '#e600e6')
+      : fillColor
     context.strokeStyle = strokeColor
 
     context.beginPath()
@@ -540,8 +539,8 @@ function flameGraph (opts) {
   }
 
   function renderHeatBar (context, node, x, y, width) {
-    var heatColor = coloringFunction(node.data, undefined, allSamples, tiers)
-    var heatStrokeColor = coloringFunction(node.data, 1.1, allSamples, tiers)
+    var heatColor = colorHash(node.data, undefined, allSamples, tiers)
+    var heatStrokeColor = colorHash(node.data, 1.1, allSamples, tiers)
     var heatHeight = Math.floor(c / 3)
 
     context.fillStyle = heatColor
@@ -567,7 +566,7 @@ function flameGraph (opts) {
     }
   }
 
-  function renderTooltip (node) {
+  function defaultRenderTooltip (node) {
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
     var transform = d3.zoomTransform(canvas)
@@ -607,7 +606,7 @@ function flameGraph (opts) {
   var hoveringIn = false
   function showTooltip (node) {
     // let's dispatch the hover event with no delay
-    const pointerCoords = {x: d3.event.offsetX, y: d3.event.offsetY}
+    const pointerCoords = { x: d3.event.offsetX, y: d3.event.offsetY }
     dispatch.call('hoverin', null, node.data, getNodeRect(node), pointerCoords)
     hoveringIn = true
 
@@ -664,7 +663,7 @@ function flameGraph (opts) {
       allSamples = data.data.value
 
       if (!firstRender) {
-        node = d3.select(this).append('div')
+        var node = d3.select(this).append('div')
           .style('position', 'relative')
         node.append('canvas')
           .attr('width', w)
@@ -866,7 +865,7 @@ function flameGraph (opts) {
 }
 
 // This function can be overridden by passing a function to opts.colorHash
-function colorHash (d, perc, allSamples, tiers) {
+function defaultColorHash (d, perc, allSamples, tiers) {
   if (!d.name) {
     return perc ? 'rgb(127, 127, 127)' : 'rgba(0, 0, 0, 0)'
   }
@@ -948,14 +947,14 @@ function createAnimation (opts, render, done) {
       animationFrame = null
       done()
     } else {
-      animationFrame = requestAnimationFrame(nextFrame)
+      animationFrame = window.requestAnimationFrame(nextFrame)
     }
   }
-  animationFrame = requestAnimationFrame(nextFrame)
+  animationFrame = window.requestAnimationFrame(nextFrame)
 
   return {
     cancel () {
-      cancelAnimationFrame(animationFrame)
+      window.cancelAnimationFrame(animationFrame)
     },
     currentX (node) {
       var prev = node.data.prev
@@ -973,4 +972,4 @@ function interpolate (start, end, ease) {
 
 module.exports = flameGraph
 module.exports.colors = colors
-module.exports.colorHash = colorHash
+module.exports.colorHash = defaultColorHash

--- a/index.js
+++ b/index.js
@@ -71,10 +71,10 @@ function flameGraph (opts) {
   var currentAnimation = null
 
   // Use custom coloring function if one has been passed in
-  var colorHash = (opts.colorHash !== undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
+  var colorHash = (opts.colorHash === undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
   // Use custom tooltip rendering function if defined
-  var renderTooltip = (opts.renderTooltip !== undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
+  var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
   onresize()
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom')
+  var dispatch = d3.dispatch('zoom','hoverin','hoverout')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -69,6 +69,7 @@ function flameGraph (opts) {
   var focusedFrame = null
   var hoverFrame = null
   var currentAnimation = null
+  var noTooltip = opts.noTooltip || false
 
   // Use custom coloring function if one has been passed in
   if (opts.colorHash) colorHash = (d, decimalAdjust, allSamples, tiers) => {
@@ -548,6 +549,21 @@ function flameGraph (opts) {
     context.stroke()
   }
 
+  function getNodeRect(node){
+    var wrapper = d3.select(element)
+    var canvas = wrapper.select('canvas').node()
+    var transform = d3.zoomTransform(canvas)
+    const x0 = transform.applyX(scaleToWidth(node.x0))
+    const x1 = transform.applyX(scaleToWidth(node.x1))
+
+    return {
+      x: x0,
+      y: transform.applyY(h - frameDepth(node) * c) - wrapper.node().scrollTop,
+      w: x1 - x0,
+      h: c
+    }
+  }
+
   function renderTooltip (node) {
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
@@ -585,7 +601,14 @@ function flameGraph (opts) {
   // Wait for 500 ms before showing the tooltip.
   var tooltipFocusNode = null
   var tooltipFocusTimeout = null
+  var hoverin = false
   function showTooltip (node) {
+
+    //let's dispatch the hover event with no delay
+    dispatch.call('hoverin', null, {...node, rect: getNodeRect(node)})
+    hoverin = true
+    if(noTooltip) return
+
     if (tooltipFocusNode === node) {
       return renderTooltip(node)
     }
@@ -597,6 +620,13 @@ function flameGraph (opts) {
   }
 
   function hideTooltip () {
+    if(hoverin == true){
+      dispatch.call('hoverout', null, null)
+      hoverin = false
+    }
+    
+    if(noTooltip) return
+
     clearTimeout(tooltipFocusTimeout)
     tooltipFocusNode = null
     tooltipFocusTimeout = setTimeout(function () {
@@ -677,18 +707,21 @@ function flameGraph (opts) {
             this.style.cursor = 'default'
             hideTooltip()
           })
-        node.append('div')
-          .style('background', '#222')
-          .style('color', '#fff')
-          .style('border-radius', '3px')
-          .style('padding', '3px')
-          .style('font-size', '10pt')
-          .style('position', 'fixed')
-          .style('display', 'none')
-          .style('z-index', 1000)
-          .classed('d3-flame-graph-tooltip', true)
-          .on('mouseover', preventHideTooltip)
-          .on('mouseout', hideTooltip)
+
+        if(noTooltip == false){
+          node.append('div')
+            .style('background', '#222')
+            .style('color', '#fff')
+            .style('border-radius', '3px')
+            .style('padding', '3px')
+            .style('font-size', '10pt')
+            .style('position', 'fixed')
+            .style('display', 'none')
+            .style('z-index', 1000)
+            .classed('d3-flame-graph-tooltip', true)
+            .on('mouseover', preventHideTooltip)
+            .on('mouseout', hideTooltip)
+        }
 
         // Adjust canvas for high DPI screens
         // - Size the image up N× using attributes

--- a/index.js
+++ b/index.js
@@ -71,14 +71,12 @@ function flameGraph (opts) {
   var currentAnimation = null
 
   // Use custom tooltip rendering function if defined
-  renderTooltip = opts.renderTooltip === undefined ? renderTooltip : node => { opts.renderTooltip && opts.renderTooltip(node) }
+  if (opts.renderTooltip !== undefined) renderTooltip = node => opts.renderTooltip && opts.renderTooltip(node)
 
   // Use custom coloring function if one has been passed in
-  if (opts.colorHash) {
-    colorHash = (d, decimalAdjust, allSamples, tiers) => {
-      return opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers })
-    }
-  }
+  if (opts.colorHash !== undefined) colorHash = (d, decimalAdjust, allSamples, tiers) => 
+    opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
+  
 
   onresize()
 
@@ -552,21 +550,6 @@ function flameGraph (opts) {
     context.rect(x, y - heatHeight, width, heatHeight)
     context.fill()
     context.stroke()
-  }
-
-  function getNodeRect (node) {
-    var wrapper = d3.select(element)
-    var canvas = wrapper.select('canvas').node()
-    var transform = d3.zoomTransform(canvas)
-    const x0 = transform.applyX(scaleToWidth(node.x0))
-    const x1 = transform.applyX(scaleToWidth(node.x1))
-
-    return {
-      x: x0,
-      y: transform.applyY(h - frameDepth(node) * c),
-      w: x1 - x0,
-      h: c
-    }
   }
 
   function getNodeRect (node) {


### PR DESCRIPTION
This PR adds:
- `renderTooltip` as an optional function. Pass `null` to disable the default tooltip or a custom function if needed
- `hoverin` and `hoverout` events, triggered when the mouse enters/leaves a node
- `animationEnd` event fired at the end of the zoom animation

The two hover events pass the hovered node.
`hoverin` passes also the `rect` object (containing the size and position of the hovered node relative to the canvas) and `pointerCoords` containing the position of the pointer when the click occurred.
