### PR TITLE
Fix/updating hover frame on mouseout

### DIFF
--- a/index.js
+++ b/index.js
@@ -702,6 +702,7 @@ function flameGraph (opts) {
             }
           })
           .on('mouseout', function () {
+            hoverFrame = null
             this.style.cursor = 'default'
             hideTooltip()
           })


### PR DESCRIPTION
Currently `mouseout` event handler doesn't reset the `hoverFrame` to null.
This means that If there's some element that overlaps the canvas, when the mouse goes over it and then back to the same position it was before  the `hoverin` event doesn't get triggered because of this line:
`if (target === hoverFrame) return`
Setting `hoverFrame = null` on `mouseout` addresses this issue.