### PR TITLE
resizing the canvas element whenever the `update` function gets executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -660,17 +660,18 @@ function flameGraph (opts) {
     // - Size the image up N× using attributes
     // - Squash it down N× using CSS
     // - Scale the context so 1px in all subsequent draw operations means Npx
-  
+
+    devicePixelRatio = window.devicePixelRatio
+
+    // let's resize the canvas
+    canvas
+      .style('width', w + 'px')
+      .style('height', h + 'px')
+      .attr('width', w * devicePixelRatio)
+      .attr('height', h * devicePixelRatio)
+
     // avoiding unnecessary ops if the pixelRatio didn't change since last time
     if (devicePixelRatio !== window.devicePixelRatio) {
-      devicePixelRatio = window.devicePixelRatio
-  
-      canvas
-        .style('width', w + 'px')
-        .style('height', h + 'px')
-        .attr('width', w * devicePixelRatio)
-        .attr('height', h * devicePixelRatio)
-  
       canvas.node().getContext('2d').scale(devicePixelRatio, devicePixelRatio)
     }
   }
@@ -870,7 +871,6 @@ function flameGraph (opts) {
 
   return chart
 }
-
 
 // This function can be overridden by passing a function to opts.colorHash
 function defaultColorHash (d, perc, allSamples, tiers) {

--- a/index.js
+++ b/index.js
@@ -70,8 +70,6 @@ function flameGraph (opts) {
   var hoverFrame = null
   var currentAnimation = null
 
-  var devicePixelRatio = null
-
   // Use custom coloring function if one has been passed in
   var colorHash = (opts.colorHash === undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
@@ -661,8 +659,7 @@ function flameGraph (opts) {
     // - Squash it down N× using CSS
     // - Scale the context so 1px in all subsequent draw operations means Npx
 
-    devicePixelRatio = window.devicePixelRatio
-
+    const devicePixelRatio = window.devicePixelRatio
     // let's resize the canvas
     canvas
       .style('width', w + 'px')
@@ -670,10 +667,7 @@ function flameGraph (opts) {
       .attr('width', w * devicePixelRatio)
       .attr('height', h * devicePixelRatio)
 
-    // avoiding unnecessary ops if the pixelRatio didn't change since last time
-    if (devicePixelRatio !== window.devicePixelRatio) {
-      canvas.node().getContext('2d').scale(devicePixelRatio, devicePixelRatio)
-    }
+    canvas.node().getContext('2d').scale(devicePixelRatio, devicePixelRatio)
   }
 
   function chart (firstRender) {


### PR DESCRIPTION
Previously when updating the canvas (as result of the resize event) the following condition was preventing the canvas to be actually updated with the new size:
`if (devicePixelRatio !== window.devicePixelRatio) {`
This resulted in the canvas cutting off part of the chart on the far right side:

![screenshot 2018-10-23 at 10 06 54](https://user-images.githubusercontent.com/1298616/47345624-7fff7580-d6ab-11e8-89a1-7d437fcadebe.png)


I am now moving this condition to control the `canvas.scale` method only.