### PR TITLE
Fix clearing canvas on all DPI / zoom / panning levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -385,7 +385,11 @@ function flameGraph (opts) {
           var context = canvas.getContext('2d')
           context.textBaseline = 'bottom'
 
+          // Ensure clearing is not affected by current zoom, panning, scaling etc
+          context.save()
+          context.setTransform(1, 0, 0, 1, 0, 0)
           context.clearRect(0, 0, canvas.width, canvas.height)
+          context.restore()
 
           withZoomTransform(context, function () {
             nodes.forEach(function (node) {


### PR DESCRIPTION
`clearRect()` is affected by scaling and such done outside it, but we
need the `canvas.width` and `canvas.height` to actually line up with the
canvas borders here. Using `setTransform()` we can remove all current
scaling transforms.