### PR TITLE
Exposing `getNodeRect`

### DIFF
--- a/index.js
+++ b/index.js
@@ -548,13 +548,7 @@ function flameGraph (opts) {
     context.stroke()
   }
 
-  function getNodeRect (nodeOrId) {
-    let node = nodeOrId
-
-    if (typeof (nodeOrId) === 'number') {
-      node = nodes.find(n => n.data.id === nodeOrId)
-    }
-
+  function getNodeRect (node) {
     if (!node) return null
 
     var wrapper = d3.select(element)
@@ -857,17 +851,18 @@ function flameGraph (opts) {
     } else update()
   }
 
-  chart.zoom = (data = nodes[0].data) => {
+  chart.zoom = (nodeData = nodes[0].data) => {
     // nodes[0] = root node
     // users of this method can zoom in on a data point
     // instead of a node.
-    const node = nodes.find(n => n.data === data)
+    const node = nodes.find(n => n.data === nodeData)
     zoom(node || nodes[0])
   }
 
-  chart.getNodeRect = id => {
+  chart.getNodeRect = nodeData => {
     // returns the node position and size on canvas, or null.
-    return typeof (id) === 'number' ? getNodeRect(id) : null
+    const node = nodes.find(n => n.data === nodeData)
+    return getNodeRect(node)
   }
 
   chart.on = dispatch.on.bind(dispatch)

--- a/index.js
+++ b/index.js
@@ -866,8 +866,8 @@ function flameGraph (opts) {
   }
 
   chart.getNodeRect = id => {
-    // returns the node position and size on canvas, or false.
-    return typeof (id) === 'number' && getNodeRect(id)
+    // returns the node position and size on canvas, or null.
+    return typeof (id) === 'number' ? getNodeRect(id) : null
   }
 
   chart.on = dispatch.on.bind(dispatch)

--- a/index.js
+++ b/index.js
@@ -555,6 +555,8 @@ function flameGraph (opts) {
       node = nodes.find(n => n.data.id === nodeOrId)
     }
 
+    if (!node) return null
+
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
     var transform = d3.zoomTransform(canvas)

--- a/index.js
+++ b/index.js
@@ -548,7 +548,13 @@ function flameGraph (opts) {
     context.stroke()
   }
 
-  function getNodeRect (node) {
+  function getNodeRect (nodeOrId) {
+    let node = nodeOrId
+
+    if (typeof (nodeOrId) === 'number') {
+      node = nodes.find(n => n.data.id === nodeOrId)
+    }
+
     var wrapper = d3.select(element)
     var canvas = wrapper.select('canvas').node()
     var transform = d3.zoomTransform(canvas)
@@ -558,8 +564,8 @@ function flameGraph (opts) {
     return {
       x: x0,
       y: transform.applyY(h - frameDepth(node) * c),
-      w: x1 - x0,
-      h: c
+      width: x1 - x0,
+      height: c
     }
   }
 
@@ -855,6 +861,11 @@ function flameGraph (opts) {
     // instead of a node.
     const node = nodes.find(n => n.data === data)
     zoom(node || nodes[0])
+  }
+
+  chart.getNodeRect = id => {
+    // returns the node position and size on canvas, or false.
+    return typeof (id) === 'number' && getNodeRect(id)
   }
 
   chart.on = dispatch.on.bind(dispatch)


### PR DESCRIPTION
With this PR d3-fg will expose the `getNodeRect` public method.
It accepts the node `data` object and it returns an object containing the node position and size (or `null` if no node is found).
The returned object has now the following shape:
`{x, y, width, height}`

This has been updated to match the object shape returned by `getClientBoundingRect`.

This method is useful when we need to overlap external components over a particular frame, like the following screenshot demonstrates:

![screenshot 2018-10-24 at 21 24 05](https://user-images.githubusercontent.com/1298616/47455879-47f35200-d7d3-11e8-8b7d-54db4c09a5ba.png)
