### PR TITLE
Allow renderLabel and click handler to be overridden, add click dispatch event

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom', 'hoverin', 'hoverout', 'animationEnd', 'clickin', 'clickout')
+  var dispatch = d3.dispatch('zoom', 'hoverin', 'hoverout', 'animationEnd', 'click')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -707,11 +707,12 @@ function flameGraph (opts) {
             const pointerCoords = { x: d3.event.offsetX, y: d3.event.offsetY }
             const target = getNodeAt(this, pointerCoords.x, pointerCoords.y)
 
-            // Passes original datum and rect / event co-ordinates, same as hoverin / hoverout dispatches
             if (target) {
-              dispatch.call('clickin', null, target.data, getNodeRect(target), pointerCoords)
+              // Passes original datum and rect / event co-ordinates, same as hoverin / hoverout dispatches
+              dispatch.call('click', null, target.data, getNodeRect(target), pointerCoords)
             } else {
-              dispatch.call('clickout', null, null)
+              // Click on the flamegraph background. Listeners can ignore it or treat it as deselection
+              dispatch.call('click', null, null, null, null)
             }
 
             // Passes d3-fg target node object, in context of DOM element

--- a/index.js
+++ b/index.js
@@ -70,8 +70,11 @@ function flameGraph (opts) {
   var hoverFrame = null
   var currentAnimation = null
 
-  // Use custom coloring function if one has been passed in
+  // Use custom coloring function if defined
   var colorHash = (opts.colorHash === undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
+
+  // Use custom text label rendering function if defined
+  var renderLabel = (opts.renderLabel === undefined) ? defaultRenderLabel : (context, node, x, y, width) => opts.renderLabel && opts.renderLabel(c, { context, node, x, y, width })
 
   // Use custom tooltip rendering function if defined
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
@@ -500,7 +503,7 @@ function flameGraph (opts) {
     }
   }
 
-  function renderLabel (context, node, x, y, width) {
+  function defaultRenderLabel (context, node, x, y, width) {
     // baseline size of 12px—for every ~3px that cellHeight grows above its baseline of 18px,
     // grow the font size 1px
     // This way the font size gets relatively smaller, giving it some breathing room at larger cell heights

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function flameGraph (opts) {
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
   // Use custom handler for clicks on canvas if defined; preserves default `this` as being the DOM object
-  var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function () { }
+  var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 
   onresize()
 
@@ -707,11 +707,11 @@ function flameGraph (opts) {
             const pointerCoords = { x: d3.event.offsetX, y: d3.event.offsetY }
             const target = getNodeAt(this, pointerCoords.x, pointerCoords.y)
 
-            // Passes d3-fg target node object, in context of DOM element
-            clickHandler.call(this, target)
-
             // Passes original datum and rect / event co-ordinates, same as hoverin / hoverout dispatches
             dispatch.call('click', null, target.data, getNodeRect(target), pointerCoords)
+
+            // Passes d3-fg target node object, in context of DOM element
+            return clickHandler.call(this, target)
           })
           .on('mousemove', function () {
             var target = getNodeAt(this, d3.event.offsetX, d3.event.offsetY)

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function flameGraph (opts) {
   var panZoom = d3.zoom().on('zoom', function () {
     update({ animate: false })
   })
-  var dispatch = d3.dispatch('zoom', 'hoverin', 'hoverout', 'animationEnd', 'click')
+  var dispatch = d3.dispatch('zoom', 'hoverin', 'hoverout', 'animationEnd', 'clickin', 'clickout')
   var selection = null
   var transitionDuration = 500
   var transitionEase = d3.easeCubicInOut
@@ -708,7 +708,11 @@ function flameGraph (opts) {
             const target = getNodeAt(this, pointerCoords.x, pointerCoords.y)
 
             // Passes original datum and rect / event co-ordinates, same as hoverin / hoverout dispatches
-            dispatch.call('click', null, target.data, getNodeRect(target), pointerCoords)
+            if (target) {
+              dispatch.call('clickin', null, target.data, getNodeRect(target), pointerCoords)
+            } else {
+              dispatch.call('clickout', null, null)
+            }
 
             // Passes d3-fg target node object, in context of DOM element
             return clickHandler.call(this, target)

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Using `d3.dispatch`, d3-fg defines events that can be listened for and responded
 
  ```js
  flamegraph.on('click', (nodeData, rect, pointerCoords) => {
-   nodeData         // Null or Object, the datum from the original data set represented by this frame, from node.data
+   nodeData         // Null or Object, this datum from the original data set (from node.data)
    rect,            // Object, the co-ordinates of this frame's rendered rectangle
    pointerCoords    // Object, the `x` and `y` co-ordinates of the click event
  }
@@ -38,7 +38,7 @@ Using `d3.dispatch`, d3-fg defines events that can be listened for and responded
 
  ```js
  flamegraph.on('zoom', (nodeData) => {
-   nodeData         // Null or Object, the datum from the original data set represented by this frame, from node.data
+   nodeData         // Null or Object, this datum from the original data set (from node.data)
  }
  ```
 
@@ -74,7 +74,7 @@ require('d3-flamegraph')({
   height,     // Number (pixels). If not set, is calculated based on tallest stack
   width,      // Number (pixels). If not set, is calculated based on clientWidth when called
   cellHeight, // Number (pixels). Defaults to 18 pixels. Font sizes scale along with this value.
-  heatBars, // Boolean, when false (the default), heat is visualized as the background colour of stack frames;
+  heatBars, // Boolean, when false (default), heat is visualized as the background colour of stack frames;
             // when true, heat is visualized by a bar drawn on _top_ of stack frames
   frameColors: { // Object, colors for the stack frame boxes.
                  // Used when `heatBars: true`, and for the "all stacks" row when `heatBars: false`

--- a/readme.md
+++ b/readme.md
@@ -22,18 +22,20 @@ var flamegraph = require('d3-flamegraph')({tree, element})
 
 Using `d3.dispatch`, d3-fg defines events that can be listened for and responded to in the calling application.
 
-- `click` On clicks anywhere on the flamegraph:
+- `clickin` On clicks that are on drawn frames on the flamegraph, before calling the click handler:
 
  ```js
- flamegraph.on('click', (nodeData, rect, pointerCoords) => {
+ flamegraph.on('clickin', (nodeData, rect, pointerCoords) => {
    nodeData         // Null or Object, this datum from the original data set (from node.data)
    rect,            // Object, the co-ordinates of this frame's rendered rectangle
    pointerCoords    // Object, the `x` and `y` co-ordinates of the click event
  }
  ```
 
+ - `clickout` On clicks outside of drawn frames, on the flamegraph background, before calling the click handler. No args passed.
+
  - `hoverin` On hovering in to a rendered frame on the flamegraph. Same args as `click`
- - `hoverout` On hovering out of a rendered frame on the flamegraph. Same args as `click`, `nodeData` expected to be `null`
+ - `hoverout` On hovering out of a rendered frame on the flamegraph. No args passed.
  - `zoom` On d3-fg executing a zoom on a frame.
 
  ```js

--- a/readme.md
+++ b/readme.md
@@ -22,17 +22,15 @@ var flamegraph = require('d3-flamegraph')({tree, element})
 
 Using `d3.dispatch`, d3-fg defines events that can be listened for and responded to in the calling application.
 
-- `clickin` On clicks that are on drawn frames on the flamegraph, before calling the click handler:
+- `click` On clicks on the flamegraph. If the click is not on a frame, all args are passed as `null` to allow for 'deselection'-like responses:
 
  ```js
- flamegraph.on('clickin', (nodeData, rect, pointerCoords) => {
+ flamegraph.on('click', (nodeData, rect, pointerCoords) => {
    nodeData         // Null or Object, this datum from the original data set (from node.data)
-   rect,            // Object, the co-ordinates of this frame's rendered rectangle
-   pointerCoords    // Object, the `x` and `y` co-ordinates of the click event
+   rect,            // Null or Object, the co-ordinates of this frame's rendered rectangle
+   pointerCoords    // Null or Object, the `x` and `y` co-ordinates of the click event
  }
  ```
-
- - `clickout` On clicks outside of drawn frames, on the flamegraph background, before calling the click handler. No args passed.
 
  - `hoverin` On hovering in to a rendered frame on the flamegraph. Same args as `click`
  - `hoverout` On hovering out of a rendered frame on the flamegraph. No args passed.


### PR DESCRIPTION
1. Makes writing the on-Canvas labels able to be disabled or overridden
2. Makes the default click action (zooming in or out) able to be disabled or overridden
    - Any function passed in `clickHandler` acts like a typical d3 event handler in that if it is not defined inside an arrow function, `this` inside the function is the relevant DOM element (the canvas)

3. Also allows `clickin` and `clickout` events to be listened to, same as `hoverin` and `hoverout`
    - So, applications can handle click events before the default d3-fg click handler, if they want to keep the default click behaviour

4. Updates the readme, with docs for all overridable functions and listenable dispatches.