### PR TITLE
Add option for hidden stack frame alignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,7 +445,10 @@ function flameGraph (opts) {
   }
 
   function renderNode (context, node, ease, state) {
+    // Hidden by filters
     if (node.data.hide) return
+    // Hidden by zoom
+    if (node.data.value === 0) return
 
     var depth = frameDepth(node)
     var width = frameWidth(node)
@@ -461,7 +464,14 @@ function flameGraph (opts) {
       x = interpolate(scaleToWidth(prev.x0), x, ease)
     }
 
-    if (width < 1) return
+    // don't bother drawing anything fancy for tiny frames, just do a box.
+    if (width < 3) {
+      context.fillStyle = heatBars || !node.parent
+        ? frameColors.fill
+        : colorHash(node.data, undefined, allSamples, tiers)
+      context.fillRect(x, y, Math.max(width, 1), c)
+      return
+    }
 
     if (state === STATE_HOVER || state === STATE_UNHOVER) {
       context.clearRect(x, y, width, c)

--- a/index.js
+++ b/index.js
@@ -321,12 +321,12 @@ function flameGraph (opts) {
   function sumChildValues (acc, node) {
     // If a child is hidden or is (an ancestor of) the focusedFrame frame, don't count it
     if (node.fade || node === focusedFrame) {
-      return acc + node.children.reduce(sumChildValues, 0)
+      return acc + (node.children ? node.children.reduce(sumChildValues, 0) : 0)
     }
     // When collapsing hidden nodes, they only count for their children's values.
     // This way there is no space between children of this hidden node and adjacent nodes.
     if (node.hide && collapseHiddenNodeWidths) {
-      return acc + node.children.reduce(sumChildValues, 0)
+      return acc + (node.children ? node.children.reduce(sumChildValues, 0) : 0)
     }
     return acc + node.value
   }

--- a/index.js
+++ b/index.js
@@ -363,9 +363,10 @@ function flameGraph (opts) {
             .sort(doSort)
 
           // Make "all stacks" as wide as every visible stack.
-          // This is important when we're zoomed in.
+          // These are d3 tree nodes with `.value` properties containing the sums from above,
+          // so we don't need sumChildValues() but can just add those sums up.
           data.value = data.children
-            ? data.children.reduce((acc, node) => sumChildValues(acc, node.data), 0)
+            ? data.children.reduce((acc, node) => acc + node.value, 0)
             : 0
         })
 

--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ function flameGraph (opts) {
   function sumChildValues (acc, node) {
     // If a child is hidden or is (an ancestor of) the focusedFrame frame, don't count it
     if (node.fade || node === focusedFrame) {
-      return acc
+      return acc + node.children.reduce(sumChildValues, 0)
     }
     // When collapsing hidden nodes, they only count for their children's values.
     // This way there is no space between children of this hidden node and adjacent nodes.
@@ -348,7 +348,7 @@ function flameGraph (opts) {
           data
             .sum(function (d) {
               // If this is the ancestor of a focusedFrame frame, use the same value (width) as the focusedFrame frame.
-              if (d.fade) return d.children.reduce(sumChildValues, 0)
+              if (d.fade) return 0
               // When collapsing hidden nodes, they don't have a width; d3 will sum up their children's widths
               if (d.hide && collapseHiddenNodeWidths) return 0
 

--- a/index.js
+++ b/index.js
@@ -448,8 +448,6 @@ function flameGraph (opts) {
   function renderNode (context, node, ease, state) {
     // Hidden by filters
     if (node.data.hide) return
-    // Hidden by zoom
-    if (node.data.value === 0) return
 
     var depth = frameDepth(node)
     var width = frameWidth(node)
@@ -467,6 +465,8 @@ function flameGraph (opts) {
 
     // don't bother drawing anything fancy for tiny frames, just do a box.
     if (width < 3) {
+      // Hidden by zoom
+      if (node.data.value === 0) return
       context.fillStyle = heatBars || !node.parent
         ? frameColors.fill
         : colorHash(node.data, undefined, allSamples, tiers)

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ require('d3-flamegraph')({
   height,     // Number (pixels). If not set, is calculated based on tallest stack
   width,      // Number (pixels). If not set, is calculated based on clientWidth when called
   cellHeight, // Number (pixels). Defaults to 18 pixels. Font sizes scale along with this value.
+  collapseHiddenNodeWidths, // Boolean, see below
   heatBars, // Boolean, when false (default), heat is visualized as the background colour of stack frames;
             // when true, heat is visualized by a bar drawn on _top_ of stack frames
   frameColors: { // Object, colors for the stack frame boxes.
@@ -119,6 +120,16 @@ require('d3-flamegraph')({
     return           // Returns target or all-stacks frame
 })
 ```
+
+### `collapseHiddenNodeWidths`
+
+Boolean, affects the widths of stack frames excluded by type filters.
+
+This is an advanced option that is best used together with `heatBars: true` and a custom sort function that does something that is useful for your visualization.
+
+When false (default), hidden frames take up horizontal space, and visible children of hidden stack frames are aligned along where the hidden frame would be. In practice, this means there may be gaps between frames but toggling filters will only ever visually move frames vertically.
+
+When true, hidden frames do not take up space, but instead all their visible children are aligned closely next to each other, to the left of their closest visible parent. In practice, this means that there are no gaps between frames, instead the amount of free space on the right of a visible frame indicates the amount of time it was at the top of the stack. When toggling filters, frames may jump horizontally.
 
 ## Dependencies
 

--- a/readme.md
+++ b/readme.md
@@ -125,11 +125,7 @@ require('d3-flamegraph')({
 
 Boolean, affects the widths of stack frames excluded by type filters.
 
-This is an advanced option that is best used together with `heatBars: true` and a custom sort function that does something that is useful for your visualization.
-
-When false (default), hidden frames take up horizontal space, and visible children of hidden stack frames are aligned along where the hidden frame would be. In practice, this means there may be gaps between frames but toggling filters will only ever visually move frames vertically.
-
-When true, hidden frames do not take up space, but instead all their visible children are aligned closely next to each other, to the left of their closest visible parent. In practice, this means that there are no gaps between frames, instead the amount of free space on the right of a visible frame indicates the amount of time it was at the top of the stack. When toggling filters, frames may jump horizontally.
+When true, hidden frames do not take up space, but instead all their visible children are aligned closely next to each other, to the left of their closest visible parent. In practice, this means that there are no gaps between frames. When toggling filters, frames may jump horizontally.
 
 ## Dependencies
 


### PR DESCRIPTION
This is a bit tough to explain so I've got words here and images down below :point_down: 

In 0x, hidden stack frames still take up space. That's visible as empty
space between different stacks: one of the stacks is a child of a hidden
stack frame. This is the easiest thing to do d3 wise and has the nice
benefit that stack frames only move vertically when you toggle frame
visibility.

This PR adds a `collapseHiddenNodeWidths: true` option to change that
behaviour. Hidden stack frames don't take up horizontal space when this
option is set. That means that child stacks of hidden stack frames are
bunched up next to each other without empty space in between. The
benefit of this approach is that, combined with `heatBars: true`, the
heat bars will be one contiguous block, and the size of this block is
directly proportional to the time that frame was at the top of the stack.
Without this option, heat bars are seen through all the gaps where
hidden stack frames are taking up space, and only the colour is
proportional to the heat.

Visually:

## collapseHiddenNodeWidths: false

![image](https://user-images.githubusercontent.com/1006268/47795562-0c9cda00-dd23-11e8-9c8a-bc3a9bff0a77.png)
![image](https://user-images.githubusercontent.com/1006268/47795626-24745e00-dd23-11e8-8296-50fad6ccc81d.png)

Here, the `_GI__` frame is a C++ frame. It's a child of a V8 frame. When the V8 frames are hidden, the C++ frame is aligned to the left of the V8 frame it's in, because the other hidden V8 frame widths still push it to the right.

## collapseHiddenNodeWidths: true

![image](https://user-images.githubusercontent.com/1006268/47795886-92b92080-dd23-11e8-8589-568c2236016c.png)
![image](https://user-images.githubusercontent.com/1006268/47795900-977dd480-dd23-11e8-816e-fbcaf617d394.png)

With this option enabled, the C++ frame is aligned to the left of the closest visible frame, rather than its direct parent.


---

This also fixes an unrelated issue that got in the way while testing this, where very narrow stack frames were not drawn at all. Now, very narrow frames are drawn at 1px width.