### PR TITLE
Put hover style in function, make it overridable

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,8 @@ function flameGraph (opts) {
   // Use custom handler for clicks on canvas if defined; preserves default `this` as being the DOM object
   var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 
+  var hoverStyle = (opts.hoverStyle === undefined) ? defaultHoverStyle : opts.hoverStyle || function (context, node, rect) { context.fill() }
+
   onresize()
 
   function onresize () {
@@ -514,10 +516,7 @@ function flameGraph (opts) {
     context.beginPath()
     context.rect(x, y, width, c)
     if (state === STATE_HOVER) {
-      context.save()
-      context.globalAlpha = 0.8
-      context.fill()
-      context.restore()
+      hoverStyle(context, node, { x, y, width, height: c })
     } else {
       context.fill()
     }
@@ -532,6 +531,13 @@ function flameGraph (opts) {
     } else {
       context.stroke()
     }
+  }
+
+  function defaultHoverStyle (context, node, rect) {
+    context.save()
+    context.globalAlpha = 0.8
+    context.fill()
+    context.restore()
   }
 
   function defaultClickHandler (target) {

--- a/index.js
+++ b/index.js
@@ -71,16 +71,13 @@ function flameGraph (opts) {
   var hoverFrame = null
   var currentAnimation = null
 
-  // Use custom coloring function if defined
+  // Overridable functions. Use custom function if passed in, default if undefined, or, do nothing (or neutral fallback) if passed null
   var colorHash = (opts.colorHash === undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
-  // Use custom text label rendering function if defined
   var renderLabel = (opts.renderLabel === undefined) ? defaultRenderLabel : (context, node, x, y, width) => opts.renderLabel && opts.renderLabel(c, { context, node, x, y, width })
 
-  // Use custom tooltip rendering function if defined
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
-  // Use custom handler for clicks on canvas if defined; preserves default `this` as being the DOM object
   var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 
   var hoverStyle = (opts.hoverStyle === undefined) ? defaultHoverStyle : opts.hoverStyle || function (context, node, rect) { context.fill() }

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,12 @@ require('d3-flamegraph')({
     target           // Null or Object, a d3-fg node representing the frame clicked on
     this             // The DOM object (in this case, the Canvas)
     return           // Returns target or all-stacks frame
+  },
+  hoverStyle: function (context, nodeData, rect) { // Applies style to the hoverred canvas frame
+    context          // Object, the Canvas DOM object being modified
+    node             // Object, a d3-fg node representing the frame being hoverred
+    rect             // Object, { x, y, width, height } of the rectangular area being styled
+  }
 })
 ```
 


### PR DESCRIPTION
Another overridable function.

3rd parties can have listeners on the hoverin / hoverout dispatches, and define their own tooltips and hover behaviours, but, currently the 0.8 opacity is always applied to the hovered frame, which isn't necessarily desirable and also, might not be cleared on mouseouts that exit the canvas before exiting the frame (e.g. via a 3rd party tooltip or overlay).

This PR allows 3rd parties to disable the default hover style, and optionally, to pass in a function applying their own styles to the appropriate segment of the canvas.
