### PR TITLE
Allow renderStackFrameBox to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,19 +71,16 @@ function flameGraph (opts) {
   var hoverFrame = null
   var currentAnimation = null
 
-  // Use custom coloring function if defined
+  // Overridable functions. Use custom function if passed in, default if undefined, or, do nothing (or neutral fallback) if passed null
   var colorHash = (opts.colorHash === undefined) ? defaultColorHash : (d, decimalAdjust, allSamples, tiers) => opts.colorHash ? opts.colorHash(stackTop, { d, decimalAdjust, allSamples, tiers }) : frameColors.fill
 
-  // Use custom text label rendering function if defined
   var renderLabel = (opts.renderLabel === undefined) ? defaultRenderLabel : (context, node, x, y, width) => opts.renderLabel && opts.renderLabel(c, { context, node, x, y, width })
 
-  // Use custom tooltip rendering function if defined
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
   var stackBoxGlobals = { frameHeight: c, STATE_HOVER, STATE_UNHOVER, STATE_IDLE, frameColors, colorHash }
   var renderStackFrameBox = (opts.renderStackFrameBox === undefined) ? defaultRenderStackFrameBox : (context, node, x, y, width, state) => opts.renderStackFrameBox && opts.renderStackFrameBox(stackBoxGlobals, { context, node, x, y, width, state })
 
-  // Use custom handler for clicks on canvas if defined; preserves default `this` as being the DOM object
   var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 
   onresize()

--- a/index.js
+++ b/index.js
@@ -80,6 +80,9 @@ function flameGraph (opts) {
   // Use custom tooltip rendering function if defined
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
+  var stackBoxGlobals = { frameHeight: c, STATE_HOVER, STATE_UNHOVER, STATE_IDLE, frameColors, colorHash }
+  var renderStackFrameBox = (opts.renderStackFrameBox === undefined) ? defaultRenderStackFrameBox : (context, node, x, y, width, state) => opts.renderStackFrameBox && opts.renderStackFrameBox(stackBoxGlobals, { context, node, x, y, width, state })
+
   // Use custom handler for clicks on canvas if defined; preserves default `this` as being the DOM object
   var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 
@@ -499,7 +502,7 @@ function flameGraph (opts) {
     }
   }
 
-  function renderStackFrameBox (context, node, x, y, width, state) {
+  function defaultRenderStackFrameBox (context, node, x, y, width, state) {
     var fillColor = heatBars || !node.parent
       ? frameColors.fill
       : colorHash(node.data, undefined, allSamples, tiers)

--- a/index.js
+++ b/index.js
@@ -78,8 +78,8 @@ function flameGraph (opts) {
 
   var renderTooltip = (opts.renderTooltip === undefined) ? defaultRenderTooltip : node => opts.renderTooltip && opts.renderTooltip(node)
 
-  var stackBoxGlobals = { frameHeight: c, STATE_HOVER, STATE_UNHOVER, STATE_IDLE, frameColors, colorHash }
-  var renderStackFrameBox = (opts.renderStackFrameBox === undefined) ? defaultRenderStackFrameBox : (context, node, x, y, width, state) => opts.renderStackFrameBox && opts.renderStackFrameBox(stackBoxGlobals, { context, node, x, y, width, state })
+  var stackBoxGlobals = { STATE_HOVER, STATE_UNHOVER, STATE_IDLE, frameColors, colorHash } // Shouldn't include `c` i.e. frame height because its value can change e.g. chart.cellHeight(newC)
+  var renderStackFrameBox = (opts.renderStackFrameBox === undefined) ? defaultRenderStackFrameBox : (context, node, x, y, width, state) => opts.renderStackFrameBox && opts.renderStackFrameBox(stackBoxGlobals, { context, node, state }, { x, y, width, height: c })
 
   var clickHandler = (opts.clickHandler === undefined) ? defaultClickHandler : opts.clickHandler || function (target) { return target || nodes ? nodes[0] : null }
 

--- a/index.js
+++ b/index.js
@@ -466,23 +466,12 @@ function flameGraph (opts) {
       x = interpolate(scaleToWidth(prev.x0), x, ease)
     }
 
-    // don't bother drawing anything fancy for tiny frames, just do a box.
-    if (width < 3) {
-      // Hidden by zoom
-      if (node.data.value === 0) return
-      context.fillStyle = heatBars || !node.parent
-        ? frameColors.fill
-        : colorHash(node.data, undefined, allSamples, tiers)
-      context.fillRect(x, y, Math.max(width, 1), c)
-      return
-    }
-
     if (state === STATE_HOVER || state === STATE_UNHOVER) {
       context.clearRect(x, y, width, c)
     }
 
     // Draw heat.
-    if (heatBars && node.parent != null &&
+    if (width >= 3 && heatBars && node.parent != null &&
         // These states mean we're redrawing on top of an existing rendered graph,
         // so we shouldn't exceed the current rectangle's boundaries; the heat will
         // still be visible from before
@@ -500,6 +489,18 @@ function flameGraph (opts) {
   }
 
   function defaultRenderStackFrameBox (context, node, x, y, width, state) {
+    // don't bother drawing anything fancy for tiny frames, just do a box.
+    if (width < 3) {
+      // Hidden by zoom
+      if (node.data.value === 0) return
+
+      context.fillStyle = heatBars || !node.parent
+        ? frameColors.fill
+        : colorHash(node.data, undefined, allSamples, tiers)
+      context.fillRect(x, y, Math.max(width, 1), c)
+      return
+    }
+
     var fillColor = heatBars || !node.parent
       ? frameColors.fill
       : colorHash(node.data, undefined, allSamples, tiers)

--- a/readme.md
+++ b/readme.md
@@ -114,9 +114,8 @@ require('d3-flamegraph')({
     } = options
     frameHeight      // Number, the default pixel height for all frames in the flamegraph
   },
-  renderStackFrameBox: function (globals, options) {
+  renderStackFrameBox: function (globals, locals, rect) {
     const {
-      frameHeight,   // Number, the default pixel height for all frames in the flamegraph
       STATE_HOVER,   // Number, for comparison against `state` to see if this frame is hoverred
       STATE_UNHOVER, // Number, as above but for frames that are no longer hoverred
       STATE_IDLE,    // Number, as above but for frames in normal, resting state
@@ -126,11 +125,9 @@ require('d3-flamegraph')({
     const {
       context,       // Object, the Canvas DOM object being modified
       node,          // Object, a d3-fg node representing the frame being labelled
-      x,             // Number, the x co-ordinate of the top left corner of the frame
-      y,             // Number, the y co-ordinate of the top left corner of the frame
-      width,         // Number, the pixel width of the frame
       state          // Number, see STATE_HOVER, STATE_UNHOVER and STATE_IDLE above
-    } = options
+    } = locals
+    rect             // Object, numeric { x, y, width, height } values for this frame's rectangle
   }
   clickHandler: function (target) { // Responds to clicks on the canvas, before calling dispatch
     target           // Null or Object, a d3-fg node representing the frame clicked on

--- a/readme.md
+++ b/readme.md
@@ -104,7 +104,7 @@ require('d3-flamegraph')({
     node             // Object, a d3-fg node representing the highlighted frame
     // no return value expected
   },
-  renderLabel: function (stackHeight, options) { // Writing on-frame Canvas labels
+  renderLabel: function (frameHeight, options) { // Writing on-frame Canvas labels
     const {
       context,       // Object, the Canvas DOM object being modified
       node,          // Object, a d3-fg node representing the frame being labelled
@@ -112,12 +112,31 @@ require('d3-flamegraph')({
       y,             // Number, the y co-ordinate of the top left corner of the frame
       width          // Number, the pixel width of the frame
     } = options
-    stackHeight      // Number, the default pixel height for all stacks in the flamegraph
+    frameHeight      // Number, the default pixel height for all frames in the flamegraph
   },
+  renderStackFrameBox: function (globals, options) {
+    const {
+      frameHeight,   // Number, the default pixel height for all frames in the flamegraph
+      STATE_HOVER,   // Number, for comparison against `state` to see if this frame is hoverred
+      STATE_UNHOVER, // Number, as above but for frames that are no longer hoverred
+      STATE_IDLE,    // Number, as above but for frames in normal, resting state
+      frameColors,   // Object, expects color definition strings keyed `fill` and `stroke`
+      colorHash      // Function, see above. Either default, override, or return frameColors.fill.
+    } = globals
+    const {
+      context,       // Object, the Canvas DOM object being modified
+      node,          // Object, a d3-fg node representing the frame being labelled
+      x,             // Number, the x co-ordinate of the top left corner of the frame
+      y,             // Number, the y co-ordinate of the top left corner of the frame
+      width,         // Number, the pixel width of the frame
+      state          // Number, see STATE_HOVER, STATE_UNHOVER and STATE_IDLE above
+    } = options
+  }
   clickHandler: function (target) { // Responds to clicks on the canvas, before calling dispatch
     target           // Null or Object, a d3-fg node representing the frame clicked on
     this             // The DOM object (in this case, the Canvas)
     return           // Returns target or all-stacks frame
+  }
 })
 ```
 


### PR DESCRIPTION
Allows the function that renders individual stack frame boxes to be overridden so applications using d3-fg can style their boxes however they want. This includes setting fills, strokes, drawing any additional lines and applying and removing any custom styles to hovered nodes.

It requires exposing quite a lot of d3-fg global variables, so these have been hoovered up and passes as an object alongside the object containing the node-specific arguments.