### PR TITLE
updating the canvas height and re-rendering when changing the cellHeight

### DIFF
--- a/index.js
+++ b/index.js
@@ -847,7 +847,7 @@ function flameGraph (opts) {
   }
 
   chart.cellHeight = function (_) {
-    if (!arguments.length) { return w }
+    if (!arguments.length) { return c }
     c = _
     h = (maxDepth(tree) + 2) * c
     onresize()

--- a/index.js
+++ b/index.js
@@ -847,8 +847,11 @@ function flameGraph (opts) {
   }
 
   chart.cellHeight = function (_) {
-    if (!arguments.length) { return c }
+    if (!arguments.length) { return w }
     c = _
+    h = (maxDepth(tree) + 2) * c
+    onresize()
+    update()
     return chart
   }
 


### PR DESCRIPTION
This PR fixes the `chart.cellHeight` method.
It now updates the canvas height and re-renders the graph whenever the cell height gets updated