### PR TITLE
Ensure minHeight is used when calculating the chart height

### DIFF
--- a/index.js
+++ b/index.js
@@ -840,6 +840,15 @@ function flameGraph (opts) {
     return chart
   }
 
+  chart.minHeight = function (_) {
+    if (!arguments.length) { return minHeight }
+    minHeight = _
+    h = h < minHeight ? minHeight : h
+    onresize()
+    update()
+    return chart
+  }
+
   chart.width = function (_) {
     if (!arguments.length) { return w }
     w = _

--- a/index.js
+++ b/index.js
@@ -852,6 +852,7 @@ function flameGraph (opts) {
     if (!arguments.length) { return c }
     c = _
     h = (maxDepth(tree) + 2) * c
+    h = h < minHeight ? minHeight : h
     onresize()
     update()
     return chart

--- a/index.js
+++ b/index.js
@@ -834,7 +834,7 @@ function flameGraph (opts) {
 
   chart.height = function (_) {
     if (!arguments.length) { return h }
-    h = _
+    h = _ < minHeight ? minHeight : _
     onresize()
     update()
     return chart


### PR DESCRIPTION
This simply uses the ternary used to set `h` initially when recalculating the chart height to help resolve [this Clinic Flame issue](https://github.com/nearform/node-clinic-flame/issues/52)