### PR TITLE
Make implicit dep "d3-dispatch" explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "d3-array": "^1.2.1",
+    "d3-dispatch": "^1.0.5",
     "d3-ease": "^1.0.3",
     "d3-hierarchy": "^1.1.6",
     "d3-scale": "^2.1.0",


### PR DESCRIPTION
There is `require('d3-dispatch')` in index.js but d3-dispatch is not in package.json, it only works because it's an implicit dep of packages that are.